### PR TITLE
Parallel processes for protection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
+.PHONY: build clean clean_benchmark
+
 build:
 	eval `opam env` 
 	dune build @install 
 
+clean: clean_benchmark
+	dune clean
+
+clean_benchmark:
+	rm -rf *.log *.datadir *.dat *.dat.old *.stderr *.stdout

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ clean: clean_benchmark
 	dune clean
 
 clean_benchmark:
-	rm -rf *.log *.datadir *.dat *.dat.old *.stderr *.stdout
+	rm -rf *.log *.datadir *.dat *.dat.old *.stderr *.stdout data.json

--- a/bin/bench.ml
+++ b/bin/bench.ml
@@ -39,6 +39,10 @@ let run_ts ts =
   let%bind res = res |> List.rev |> Deferred.List.all in
   return res
 
+let get_not_failure r = match%map r with
+  | O.Types.Failure -> raise @@ Failure "Got failure from operation"
+  | _ -> r
+
 let run_latencies throughput n ps =
   Log.info (fun m -> m "Setting up latency test\n") ;
   let node_list =
@@ -46,7 +50,7 @@ let run_latencies throughput n ps =
   in
   let client = O.Client.new_client (List.map node_list ~f:snd) in
   let test = Bytes.of_string "test" in
-  let%bind _ = O.Client.op_write client ~k:test ~v:test in
+  let%bind _ = O.Client.op_write client ~k:test ~v:test |> get_not_failure in
   let period = Float.(1. / throughput) in
   let start = Time.now () in
   let start = Time.(add start Span.(of_ms 500.)) in
@@ -58,7 +62,7 @@ let run_latencies throughput n ps =
           let st =
             Time_ns.now () |> Time_ns.to_span_since_epoch |> Time_ns.Span.to_sec
           in
-          let%bind _ = O.Client.op_write client ~k:test ~v:test in
+          let%bind _ = O.Client.op_write client ~k:test ~v:test |> get_not_failure in
           let ed =
             Time_ns.now () |> Time_ns.to_span_since_epoch |> Time_ns.Span.to_sec
           in

--- a/bin/bench.ml
+++ b/bin/bench.ml
@@ -36,8 +36,8 @@ let run_ts ts =
         upon p (printi i) ;
         return (p :: acc))
   in
-  print_endline "" ;
-  res |> List.rev |> Deferred.List.all
+  let%bind res = res |> List.rev |> Deferred.List.all in
+  return res
 
 let run_latencies throughput n ps =
   Log.info (fun m -> m "Setting up latency test\n") ;
@@ -95,6 +95,7 @@ let main target_throughput n output portss =
     let iter ports =
       let jsonpath = match output with None -> "data.json" | Some s -> s in
       let%bind res = run_latencies target_throughput n ports in
+      Log.info (fun m -> m "");
       Log.info (fun m -> m "%a\n" pp_stats res) ;
       let json = test_res_to_yojson res in
       Yojson.Safe.to_file jsonpath json ;

--- a/bin/bench.ml
+++ b/bin/bench.ml
@@ -34,14 +34,17 @@ let run_ts ts =
         let%bind () = at start in
         let p = f () in
         upon p (printi i) ;
-        return (p :: acc))
+        return (p :: acc) )
   in
   let%bind res = res |> List.rev |> Deferred.List.all in
   return res
 
-let get_not_failure r = match%map r with
-  | O.Types.Failure -> raise @@ Failure "Got failure from operation"
-  | _ -> r
+let get_not_failure r =
+  match%map r with
+  | O.Types.Failure ->
+      raise @@ Failure "Got failure from operation"
+  | _ ->
+      r
 
 let run_latencies throughput n ps =
   Log.info (fun m -> m "Setting up latency test\n") ;
@@ -62,13 +65,15 @@ let run_latencies throughput n ps =
           let st =
             Time_ns.now () |> Time_ns.to_span_since_epoch |> Time_ns.Span.to_sec
           in
-          let%bind _ = O.Client.op_write client ~k:test ~v:test |> get_not_failure in
+          let%bind _ =
+            O.Client.op_write client ~k:test ~v:test |> get_not_failure
+          in
           let ed =
             Time_ns.now () |> Time_ns.to_span_since_epoch |> Time_ns.Span.to_sec
           in
           return (st, ed)
         in
-        (f, start))
+        (f, start) )
   in
   let%bind res = run_ts ts in
   let results = Array.of_list res in
@@ -99,7 +104,7 @@ let main target_throughput n output portss =
     let iter ports =
       let jsonpath = match output with None -> "data.json" | Some s -> s in
       let%bind res = run_latencies target_throughput n ports in
-      Log.info (fun m -> m "");
+      Log.info (fun m -> m "") ;
       Log.info (fun m -> m "%a\n" pp_stats res) ;
       let json = test_res_to_yojson res in
       Yojson.Safe.to_file jsonpath json ;

--- a/bin/bench_wal.ml
+++ b/bin/bench_wal.ml
@@ -63,7 +63,7 @@ let throughput file n write_size =
         let%bind () = T.datasync wal in
         let ed = Time.now () |> Time.to_span_since_epoch |> Time.Span.to_sec in
         Queue.enqueue result_q (start, ed) ;
-        return ())
+        return () )
       stream
   in
   Log.info (fun m -> m "Finished throughput test!\n") ;

--- a/bin/client.ml
+++ b/bin/client.ml
@@ -17,7 +17,8 @@ let put =
     (fun ps k v () ->
       let c = C.new_client ps in
       let%map res = C.op_write c ~k ~v in
-      res |> [%sexp_of: Types.op_result] |> Sexp.to_string_hum |> print_endline)
+      res |> [%sexp_of: Types.op_result] |> Sexp.to_string_hum |> print_endline
+      )
 
 let get =
   Command.async_spec ~summary:"Get request"
@@ -28,7 +29,8 @@ let get =
     (fun ps k () ->
       let c = C.new_client ps in
       let%map res = C.op_read c k in
-      res |> [%sexp_of: Types.op_result] |> Sexp.to_string_hum |> print_endline)
+      res |> [%sexp_of: Types.op_result] |> Sexp.to_string_hum |> print_endline
+      )
 
 let reporter =
   let report src level ~over k msgf =

--- a/bin/dune
+++ b/bin/dune
@@ -17,7 +17,7 @@
 (executable
  (name bench)
  (public_name ocamlpaxos-bench)
- (libraries ocamlpaxos owl core async yojson)
+ (libraries ocamlpaxos owl core async yojson async.log_extended)
  (preprocess
   (pps ppx_jane ppx_deriving_yojson))
  (modules bench))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -44,9 +44,10 @@ let command =
         ; Utils.logger
         ; Owal.logger
         ; Paxos_core.logger
+        ; Paxos_core.io_logger
         ; Client_handler.logger ] ~f:(fun log ->
           Async.Log.set_level log global_level ;
-          Async.Log.set_output log global_output) ;
+          Async.Log.set_output log global_output ) ;
       let tick_speed = Time.Span.of_sec tick_speed in
       let batch_timeout = Time.Span.of_ms batch_timeout in
       let%bind () =
@@ -61,9 +62,8 @@ let command =
           ~election_timeout ~tick_speed ~batch_size ~batch_timeout
       in
       let i = Ivar.create () in
-      Signal.handle Signal.terminating ~f:(fun _ -> Ivar.fill i ());
-      Ivar.read i
-      )
+      Signal.handle Signal.terminating ~f:(fun _ -> Ivar.fill i ()) ;
+      Ivar.read i )
 
 let () =
   Fmt_tty.setup_std_outputs () ;

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -27,23 +27,28 @@ let command =
       +> anon ("node_id" %: int)
       +> anon ("node_list" %: node_list)
       +> anon ("datadir" %: string)
-      +> anon ("listen_address" %: int)
+      +> anon ("external_port" %: int)
+      +> anon ("internal_port" %: int)
       +> anon ("election_timeout" %: int)
       +> anon ("tick_speed" %: float)
-      +> flag "-s" ~doc:" Size of batches" (optional_with_default 1 int)
-      +> flag "-d" ~doc:" Time before batch is dispatched in ms"
-           (optional_with_default 100. float)
+      +> flag "-s" ~doc:" Size limit of batches" (optional_with_default 1 int)
+      +> flag "-d" ~doc:" Time limit of batches in ms"
+           (optional_with_default 50. float)
       +> log_param)
-    (fun node_id node_list datadir listen_port election_timeout tick_speed
-         batch_size dispatch_timeout () () ->
+    (fun node_id node_list datadir external_port internal_port election_timeout
+         tick_speed batch_size batch_timeout () () ->
       let global_level = Async.Log.Global.level () in
       let global_output = Async.Log.Global.get_output () in
-      List.iter [Infra.logger; Utils.logger; Owal.logger; Paxos_core.logger]
-        ~f:(fun log ->
+      List.iter
+        [ Infra.logger
+        ; Utils.logger
+        ; Owal.logger
+        ; Paxos_core.logger
+        ; Client_handler.logger ] ~f:(fun log ->
           Async.Log.set_level log global_level ;
           Async.Log.set_output log global_output) ;
       let tick_speed = Time.Span.of_sec tick_speed in
-      let dispatch_timeout = Time.Span.of_ms dispatch_timeout in
+      let batch_timeout = Time.Span.of_ms batch_timeout in
       let%bind () =
         match%bind Sys.file_exists_exn datadir with
         | true ->
@@ -52,13 +57,12 @@ let command =
             Unix.mkdir datadir
       in
       let%bind (_ : Infra.t) =
-        Infra.create ~node_id ~node_list ~datadir ~listen_port ~election_timeout
-          ~tick_speed ~batch_size ~dispatch_timeout
+        Infra.create ~node_id ~node_list ~datadir ~external_port ~internal_port
+          ~election_timeout ~tick_speed ~batch_size ~batch_timeout
       in
-      let%bind () = after (Time.Span.of_sec 20.) in
-      return ())
+      Deferred.never ())
 
 let () =
   Fmt_tty.setup_std_outputs () ;
   Fmt.pr "%a" (Fmt.array ~sep:Fmt.sp Fmt.string) (Sys.get_argv ()) ;
-  Command.run command
+  Rpc_parallel.start_app command

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -60,7 +60,10 @@ let command =
         Infra.create ~node_id ~node_list ~datadir ~external_port ~internal_port
           ~election_timeout ~tick_speed ~batch_size ~batch_timeout
       in
-      Deferred.never ())
+      let i = Ivar.create () in
+      Signal.handle Signal.terminating ~f:(fun _ -> Ivar.fill i ());
+      Ivar.read i
+      )
 
 let () =
   Fmt_tty.setup_std_outputs () ;

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -38,7 +38,8 @@ let command =
          batch_size dispatch_timeout () () ->
       let global_level = Async.Log.Global.level () in
       let global_output = Async.Log.Global.get_output () in
-      List.iter [Infra.logger; Utils.logger; Owal.logger; Paxos_core.logger] ~f:(fun log ->
+      List.iter [Infra.logger; Utils.logger; Owal.logger; Paxos_core.logger]
+        ~f:(fun log ->
           Async.Log.set_level log global_level ;
           Async.Log.set_output log global_output) ;
       let tick_speed = Time.Span.of_sec tick_speed in
@@ -55,8 +56,7 @@ let command =
           ~tick_speed ~batch_size ~dispatch_timeout
       in
       let%bind () = after (Time.Span.of_sec 20.) in
-      return ()
-    )
+      return ())
 
 let () =
   Fmt_tty.setup_std_outputs () ;

--- a/dune-project
+++ b/dune-project
@@ -15,6 +15,7 @@
     (ocaml (>= 4.08.0))
     core
     async
+    rpc_parallel
     ppx_jane
     ppx_log
     ppx_deriving_yojson

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -10,40 +10,42 @@ let logger =
     ~transform:(fun m -> Message.add_tags m [("src", "Client")])
     ()
 
-type t =
-  {conns: PC.Rpc.t list; connection_retry: Time.Span.t; retry_delay: Time.Span.t}
+type t = {conns: PC.Rpc.t list; retry_delay: Time.Span.t}
 
-let send =
-  let dispatch op ivar t ongoing conn =
-    let req =
-      match PC.Rpc.current_connection conn with
-      | Some conn ->
-          Rpc.Rpc.dispatch Types.RPCs.client_request conn op
-      | None ->
-          let%bind conn = PC.Rpc.connected conn in
-          Rpc.Rpc.dispatch Types.RPCs.client_request conn op
+let get_current_conns t = List.filter_map t.conns ~f:PC.Rpc.current_connection
+
+let send t op =
+  let retry_loop () =
+    let conns = get_current_conns t in
+    (* For each conn send out request
+       match response with
+       | Ok (Ok v) -> return v
+       | Ok (Error `Unapplied) -> do nothing
+       | Error e ->
+                log error;
+                do nothing
+    *)
+    let reqs =
+      List.map conns ~f:(fun conn ->
+          match%map Rpc.Rpc.dispatch Types.RPCs.client_request conn op with
+          | Ok (Ok v) ->
+              Some (`Finished v)
+          | Ok (Error `Unapplied) ->
+              None
+          | Error e ->
+              [%log.error
+                logger "Error while dispatching request" (e : Error.t)] ;
+              None )
     in
-    upon req (function
-      | Ok (Ok (Types.Success as v)) ->
-          Ivar.fill_if_empty ivar (`Finished v)
-      | Ok (Ok (Types.ReadSuccess _ as v)) ->
-          Ivar.fill_if_empty ivar (`Finished v)
-      | Ok (Ok (Types.Failure as v)) ->
-          Ivar.fill_if_empty ivar (`Finished v)
-      | Ok (Error `Unapplied) ->
-          decr ongoing ;
-          if !ongoing <= 0 then Ivar.fill_if_empty ivar (`Repeat (op, t))
-      | Error e ->
-          [%log.error logger "Error while dispatching request" (e : Error.t)] ;
-          decr ongoing ;
-          if !ongoing <= 0 then Ivar.fill_if_empty ivar (`Repeat (op, t)))
+    let p_timeout =
+      after t.retry_delay >>= fun () -> return @@ Some (`Repeat ())
+    in
+    let ivar = Ivar.create () in
+    List.iter (p_timeout :: reqs) ~f:(fun p ->
+        upon p (function Some v -> Ivar.fill_if_empty ivar v | None -> ()) ) ;
+    Ivar.read ivar
   in
-  let handle_ivar op t i =
-    let ongoing = ref @@ List.length t.conns in
-    List.iter t.conns ~f:(dispatch op i t ongoing)
-  in
-  let repeater (op, t) = Deferred.create (handle_ivar op t) in
-  fun t op -> Deferred.repeat_until_finished (op, t) repeater
+  Deferred.repeat_until_finished () retry_loop
 
 let op_read t k = send t Types.{op= Read (Bytes.to_string k); id= Id.create ()}
 
@@ -51,9 +53,8 @@ let op_write t ~k ~v =
   send t
     Types.{op= Write (Bytes.to_string k, Bytes.to_string v); id= Id.create ()}
 
-let new_client ?(connection_retry = Time.Span.of_sec 1.)
-    ?(retry_delay = Time.Span.of_sec 1.) addresses =
+let new_client ?(retry_delay = Time.Span.of_sec 1.) addresses =
   let conns = List.map addresses ~f:connect_persist in
-  {conns; connection_retry; retry_delay}
+  {conns; retry_delay}
 
 let close t = Deferred.List.iter ~how:`Parallel t.conns ~f:PC.Rpc.close

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -24,11 +24,13 @@ let send =
           Rpc.Rpc.dispatch Types.RPCs.client_request conn op
     in
     upon req (function
-      | Ok (Types.Success as v) ->
+      | Ok (Ok (Types.Success as v)) ->
           Ivar.fill_if_empty ivar (`Finished v)
-      | Ok (Types.ReadSuccess _ as v) ->
+      | Ok (Ok (Types.ReadSuccess _ as v)) ->
           Ivar.fill_if_empty ivar (`Finished v)
-      | Ok Types.Failure ->
+      | Ok (Ok (Types.Failure as v)) ->
+          Ivar.fill_if_empty ivar (`Finished v)
+      | Ok (Error `Unapplied) ->
           decr ongoing ;
           if !ongoing <= 0 then Ivar.fill_if_empty ivar (`Repeat (op, t))
       | Error e ->

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -14,7 +14,7 @@ val op_write : t -> k:bytes -> v:bytes -> op_result Deferred.t
 (** [op_write t k v] writes [v] to key [k] *)
 
 val new_client :
-  ?connection_retry:Time.Span.t -> ?retry_delay:Time.Span.t -> string list -> t
+  ?retry_delay:Time.Span.t -> string list -> t
 (** [new_client addresses] Creates a new client connected to the servers listed in [addresses]. If a server is unreachable it will keep trying to reconnect to it. *)
 
 val close : t -> unit Deferred.t

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -13,8 +13,7 @@ val op_read : t -> bytes -> op_result Deferred.t
 val op_write : t -> k:bytes -> v:bytes -> op_result Deferred.t
 (** [op_write t k v] writes [v] to key [k] *)
 
-val new_client :
-  ?retry_delay:Time.Span.t -> string list -> t
+val new_client : ?retry_delay:Time.Span.t -> string list -> t
 (** [new_client addresses] Creates a new client connected to the servers listed in [addresses]. If a server is unreachable it will keep trying to reconnect to it. *)
 
 val close : t -> unit Deferred.t

--- a/lib/client_handler.ml
+++ b/lib/client_handler.ml
@@ -1,0 +1,219 @@
+open! Core
+open! Async
+open! Ppx_log_async
+module H = Hashtbl
+open Types
+open Types.MessageTypes
+open! Utils
+open Rpc_parallel
+
+let logger =
+  let open Async_unix.Log in
+  create ~level:`Info ~output:[] ~on_error:`Raise
+    ~transform:(fun m -> Message.add_tags m [("src", "Client handler")])
+    ()
+
+module T = struct
+  (* Basic idea is that the main process contacts this one explicitly for a batch
+     We read that batch off of the cr_pipe.
+     When a request arrives we put it in that pipe.
+  *)
+  type request_batch = client_request list [@@deriving bin_io]
+
+  type return_result_t = command_id * client_response [@@deriving bin_io]
+
+  type 'a functions =
+    { get_batch: ('a, unit, request_batch) Function.t
+    ; return_result: ('a, return_result_t, unit) Function.t }
+
+  module Worker_state = struct
+    type init_arg =
+      { external_port: int
+      ; batch_size: int
+      ; batch_timeout: Time.Span.t
+      ; log_level: Log.Level.t }
+    [@@deriving bin_io]
+
+    type t =
+      { client_ivars: (command_id, client_response Ivar.t list) H.t
+      ; client_results: (command_id, op_result) H.t
+      ; cr_pipe: client_request rd_wr_pipe
+      ; batch_size: int
+      ; batch_timeout: Time.Span.t }
+  end
+
+  module Connection_state = struct
+    type init_arg = unit [@@deriving bin_io]
+
+    type t = unit
+  end
+
+  module Functions
+      (C : Rpc_parallel.Creator
+             with type worker_state := Worker_state.t
+              and type connection_state := Connection_state.t) =
+  struct
+    open Worker_state
+
+    let client_handler_impl =
+      [ Rpc.Rpc.implement RPCs.client_request (fun t cr ->
+            [%log.global.debug "Received" (cr.id : Id.t)] ;
+            match H.find t.client_results cr.id with
+            | Some result ->
+                return (Ok result)
+            | None ->
+                Deferred.create (fun i ->
+                    [%log.global.debug "Adding to pipe" (cr.id : Id.t)] ;
+                    H.add_multi t.client_ivars ~key:cr.id ~data:i ;
+                    Pipe.write_without_pushback t.cr_pipe.wr cr)) ]
+
+    let init_worker_state {external_port; batch_size; batch_timeout; log_level}
+        =
+      Log.Global.set_level log_level ;
+      let rd, wr = Pipe.create ~info:[%message "cr_pipe"] () in
+      let t =
+        { client_ivars= H.create (module Id)
+        ; client_results= H.create (module Id)
+        ; cr_pipe= {rd; wr}
+        ; batch_size
+        ; batch_timeout }
+      in
+      let implementations =
+        Rpc.Implementations.create_exn ~implementations:client_handler_impl
+          ~on_unknown_rpc:`Continue
+      in
+      let on_handler_error =
+        `Call
+          (fun _ e -> [%log.error logger "Error while handling msg" (e : exn)])
+      in
+      let%bind (_ : (Socket.Address.Inet.t, int) Tcp.Server.t) =
+        Tcp.Server.create (Tcp.Where_to_listen.of_port external_port)
+          ~on_handler_error (fun _addr reader writer ->
+            Rpc.Connection.server_with_close reader writer ~implementations
+              ~connection_state:(fun _ -> t)
+              ~on_handshake_error:`Ignore)
+      in
+      return t
+
+    let init_connection_state ~connection:_ ~worker_state:_ () = Deferred.unit
+
+    let get_batch_fn t =
+      [%log.global.debug "Getting batch"] ;
+      match%bind Pipe.read t.cr_pipe.rd with
+      | `Eof ->
+          [%log.global.debug "Getting batch"] ;
+          assert false
+      | `Ok fst ->
+          [%log.global.debug "Got first element, attempting to get more"] ;
+          let batch = ref [fst] in
+          let cutoff = ref false in
+          let rec loop rem =
+            let%bind (_ : [`Eof | `Ok]) = Pipe.values_available t.cr_pipe.rd in
+            match () with
+            | () when !cutoff ->
+                Deferred.unit
+            | () -> (
+              match Pipe.read_now' ~max_queue_length:rem t.cr_pipe.rd with
+              | `Eof | `Nothing_available ->
+                  assert false
+              | `Ok q ->
+                  Queue.iter q ~f:(fun v -> batch := v :: !batch) ;
+                  if Queue.length q = rem then Deferred.unit
+                  else loop (rem - Queue.length q) )
+          in
+          let batch_gather = loop (t.batch_size - 1) in
+          let batch_timout = after t.batch_timeout in
+          let%bind () =
+            choose
+              [ choice batch_gather (fun () ->
+                    [%log.global.debug "Filled batch"])
+              ; choice batch_timout (fun () ->
+                    [%log.global.debug "Batch timed out"]) ]
+          in
+          cutoff := true ;
+          return !batch
+
+    let%expect_test "correct_batching" =
+      let%bind state =
+        init_worker_state
+          { external_port= 12345
+          ; batch_size= 10
+          ; batch_timeout= Time.Span.of_sec 0.1
+          ; log_level= `Info }
+      in
+      let command = Command.{op= Read ""; id= Id.create ()} in
+      Pipe.write_without_pushback state.cr_pipe.wr command ;
+      let%bind batch = get_batch_fn state in
+      [%message (batch : command list) ~batch_size:(List.length batch : int)]
+      |> Sexp.to_string_hum |> print_endline ;
+      let%bind () =
+        [%expect {| ((batch (((op (Read "")) (id 0)))) (batch_size 1)) |}]
+      in
+      Pipe.write_without_pushback state.cr_pipe.wr command ;
+      let%bind batch = get_batch_fn state in
+      [%message (batch : command list) ~batch_size:(List.length batch : int)]
+      |> Sexp.to_string_hum |> print_endline ;
+      let%bind () =
+        [%expect {| ((batch (((op (Read "")) (id 0)))) (batch_size 1)) |}]
+      in
+      for _ = 0 to 20 do
+        Pipe.write_without_pushback state.cr_pipe.wr command
+      done ;
+      let%bind batch = get_batch_fn state in
+      [%message (batch : command list) ~batch_size:(List.length batch : int)]
+      |> Sexp.to_string_hum |> print_endline ;
+      let%bind () =
+        [%expect
+          {|
+        ((batch
+          (((op (Read "")) (id 0)) ((op (Read "")) (id 0)) ((op (Read "")) (id 0))
+           ((op (Read "")) (id 0)) ((op (Read "")) (id 0)) ((op (Read "")) (id 0))
+           ((op (Read "")) (id 0)) ((op (Read "")) (id 0)) ((op (Read "")) (id 0))
+           ((op (Read "")) (id 0))))
+         (batch_size 10)) |}]
+      in
+      Deferred.unit
+
+    let get_batch =
+      C.create_rpc ~name:"get_batch"
+        ~f:(fun ~worker_state:t ~conn_state:() () -> get_batch_fn t)
+        ~bin_input:bin_unit ~bin_output:bin_request_batch ()
+
+    let return_result =
+      C.create_one_way ~name:"return_results"
+        ~f:(fun ~worker_state:t ~conn_state:() (cmd_id, result) ->
+          ( match result with
+          | Error _ ->
+              ()
+          | Ok result ->
+              H.set t.client_results ~key:cmd_id ~data:result ) ;
+          let ivars = H.find_multi t.client_ivars cmd_id in
+          List.iter ivars ~f:(fun i -> Ivar.fill i result) ;
+          H.remove_multi t.client_ivars cmd_id)
+        ~bin_input:bin_return_result_t ()
+
+    let functions = {get_batch; return_result}
+  end
+end
+
+module M = Rpc_parallel.Make (T)
+include M
+module Shutdown_on = M.Shutdown_on (Monad.Ident)
+
+let spawn_client_handler ~external_port ~batch_size ~batch_timeout =
+  let args =
+    T.Worker_state.
+      {external_port; batch_size; batch_timeout; log_level= Log.level logger}
+  in
+  let%bind conn =
+    spawn_exn ~shutdown_on:Shutdown_on.Connection_closed
+      ~redirect_stdout:`Dev_null ~redirect_stderr:`Dev_null args
+      ~on_failure:Error.raise ~connection_state_init_arg:()
+  in
+  let%bind client_log =
+    Connection.run_exn conn ~f:Rpc_parallel.Function.async_log ~arg:()
+  in
+  Pipe.iter client_log ~f:(fun msg -> Log.message logger msg ; Deferred.unit)
+  |> don't_wait_for ;
+  [%log.debug logger "Set up client"] ;
+  return conn

--- a/lib/client_handler.ml
+++ b/lib/client_handler.ml
@@ -76,7 +76,7 @@ module T = struct
         let rd, wr = Pipe.create ~info:[%message "cr_batch_pipe"] () in
         {rd; wr}
       in
-      let rec loop batch_state =
+      let loop batch_state =
         let read_pipe ?timeout q size =
           match%bind Pipe.read' ~max_queue_length:size rd with
           | `Eof ->
@@ -106,7 +106,7 @@ module T = struct
             match enabled () |> List.hd_exn with
             | `Timeout ->
                 Pipe.write_without_pushback output.wr (Fqueue.to_list q) ;
-                loop `Empty
+                return `Empty
             | `ValuesAvailable ->
                 read_pipe q (batch_size - Fqueue.length q) )
       in

--- a/lib/client_handler.ml
+++ b/lib/client_handler.ml
@@ -175,9 +175,12 @@ module T = struct
       Deferred.unit
 
     let get_batch =
-      C.create_rpc ~name:"get_batch"
-        ~f:(fun ~worker_state:t ~conn_state:() () -> get_batch_fn t)
-        ~bin_input:bin_unit ~bin_output:bin_request_batch ()
+      let sequencer = Sequencer.create () in
+      let f ~worker_state:t ~conn_state:() () =
+        Throttle.enqueue sequencer (fun () -> get_batch_fn t)
+      in
+      C.create_rpc ~name:"get_batch" ~f ~bin_input:bin_unit
+        ~bin_output:bin_request_batch ()
 
     let return_result =
       C.create_one_way ~name:"return_results"

--- a/lib/client_handler.ml
+++ b/lib/client_handler.ml
@@ -89,6 +89,7 @@ module T = struct
       let%bind (_ : (Socket.Address.Inet.t, int) Tcp.Server.t) =
         Tcp.Server.create (Tcp.Where_to_listen.of_port external_port)
           ~on_handler_error (fun _addr reader writer ->
+              [%log.global.debug "Client connected"];
             Rpc.Connection.server_with_close reader writer ~implementations
               ~connection_state:(fun _ -> t)
               ~on_handshake_error:`Ignore)

--- a/lib/client_handler.ml
+++ b/lib/client_handler.ml
@@ -189,7 +189,6 @@ let spawn_client_handler ~external_port ~batch_size ~batch_timeout =
     T.Worker_state.
       {external_port; batch_size; batch_timeout; log_level= Log.level logger}
   in
-  let%bind cwd = Unix.getcwd () in
   let%bind conn =
     spawn_exn ~shutdown_on:Shutdown_on.Connection_closed
       ~redirect_stdout:`Dev_null ~redirect_stderr:`Dev_null args

--- a/lib/client_handler.ml
+++ b/lib/client_handler.ml
@@ -81,7 +81,7 @@ module T = struct
           match%bind Pipe.read' ~max_queue_length:size rd with
           | `Eof ->
               [%log.global.error "Client request pipe unexpectedly closed"] ;
-              assert false
+              Deferred.never ()
           | `Ok q' -> (
               let q = Queue.fold q' ~init:q ~f:Fqueue.enqueue in
               match () with
@@ -154,7 +154,7 @@ module T = struct
       match%bind Pipe.values_available t.cr_batch_pipe.rd with
       | `Eof ->
           [%log.global.error "Client request pipe unexpectedly closed"] ;
-          assert false
+          Deferred.never ()
       | `Ok ->
           Deferred.unit
 
@@ -168,7 +168,7 @@ module T = struct
       match%bind Pipe.read t.cr_batch_pipe.rd with
       | `Eof ->
           [%log.global.error "Client request pipe unexpectedly closed"] ;
-          assert false
+          Deferred.never ()
       | `Ok l ->
           [%log.global.debug "Got batch"] ; return l
 
@@ -186,7 +186,7 @@ module T = struct
           | Ok result ->
               H.set t.client_results ~key:cmd_id ~data:result ) ;
           let ivars = H.find_multi t.client_ivars cmd_id in
-          List.iter ivars ~f:(fun i -> Ivar.fill i result) ;
+          List.iter ivars ~f:(fun i -> Ivar.fill_if_empty i result) ;
           H.remove_multi t.client_ivars cmd_id )
         ~bin_input:bin_return_result_t ()
 

--- a/lib/dune
+++ b/lib/dune
@@ -2,6 +2,7 @@
  (name ocamlpaxos)
  (public_name ocamlpaxos)
  (inline_tests)
- (libraries base core async logs logs.fmt fmt.tty ppx_log rpc_parallel)
+ (libraries base core async logs logs.fmt fmt.tty ppx_log rpc_parallel
+   accessor_async)
  (preprocess
-  (pps ppx_jane ppx_log)))
+  (pps ppx_jane ppx_log ppx_accessor)))

--- a/lib/dune
+++ b/lib/dune
@@ -3,6 +3,6 @@
  (public_name ocamlpaxos)
  (inline_tests)
  (libraries base core async logs logs.fmt fmt.tty ppx_log rpc_parallel
-   accessor_async)
+   accessor_async core_profiler)
  (preprocess
   (pps ppx_jane ppx_log ppx_accessor)))

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,6 @@
  (name ocamlpaxos)
  (public_name ocamlpaxos)
  (inline_tests)
- (libraries base core async logs logs.fmt fmt.tty odbutils ppx_log
-   core_profiler)
+ (libraries base core async logs logs.fmt fmt.tty ppx_log rpc_parallel)
  (preprocess
   (pps ppx_jane ppx_log)))

--- a/lib/dune
+++ b/lib/dune
@@ -2,6 +2,7 @@
  (name ocamlpaxos)
  (public_name ocamlpaxos)
  (inline_tests)
- (libraries base core async logs logs.fmt fmt.tty odbutils ppx_log core_profiler)
+ (libraries base core async logs logs.fmt fmt.tty odbutils ppx_log
+   core_profiler)
  (preprocess
   (pps ppx_jane ppx_log)))

--- a/lib/infra.ml
+++ b/lib/infra.ml
@@ -34,7 +34,8 @@ let batch_available_watch t =
     ~arg:()
 
 let get_request_batch t =
-  CH.Connection.run_exn t.external_server ~f:CH.functions.get_batch ~arg:()
+  let%bind batch, _ = CH.Connection.run_exn t.external_server ~f:CH.functions.get_batch ~arg:() in
+  return batch
 
 let return_result t id res =
   CH.Connection.run_exn t.external_server ~f:CH.functions.return_result

--- a/lib/infra.ml
+++ b/lib/infra.ml
@@ -149,11 +149,12 @@ let deque_n q n =
         loop (Queue.dequeue_exn q :: acc, i + 1) (n - 1)
   in
   let xs, l = loop ([], 0) n in
-  List.rev xs, l
+  (List.rev xs, l)
 
 let%expect_test "dequeue_n" =
   let q = Queue.of_list [1; 2; 3; 4] in
-  deque_n q 3 |> [%sexp_of: int list * int] |> Sexp.to_string_hum |> print_endline ;
+  deque_n q 3 |> [%sexp_of: int list * int] |> Sexp.to_string_hum
+  |> print_endline ;
   [%expect {| (1 2 3) |}]
 
 let batch_probe = Probe.create ~name:"Batch_size" ~units:Profiler_units.Int
@@ -173,12 +174,11 @@ let handle_ev_q t =
       | ()
         when Queue.length t.ev_q.client_reqs >= t.client_batch_size
              || !batch_counter >= batching_freq ->
-          if !batch_counter >= batching_freq then
-          batch_counter := 0 ;
+          if !batch_counter >= batching_freq then batch_counter := 0 ;
           let batch, batch_size =
             deque_n t.ev_q.client_reqs t.client_batch_size
           in
-          Probe.record batch_probe batch_size;
+          Probe.record batch_probe batch_size ;
           [%log.debug logger (batch_size : int)] ;
           let htbl = H.of_alist_exn (module Types.Command) batch in
           let ((pre, _, _) as actions) =

--- a/lib/infra.ml
+++ b/lib/infra.ml
@@ -55,79 +55,78 @@ let rec advance_state_machine t = function
 let get_ok v =
   match v with Error (`Msg s) -> raise @@ Invalid_argument s | Ok v -> v
 
+let short_circuit f p =
+  match Deferred.peek p with Some v -> f v | None -> upon p f
+
 let send : type query. t -> int -> query Rpc.One_way.t -> query -> unit =
  fun t target rpc msg ->
   let conn = H.find_exn t.conns target in
   let handler conn =
     match Rpc.One_way.dispatch' rpc conn msg with
-    | Ok () ->
-        ()
+    | Ok () -> ()
     | Error e ->
         Async_rpc_kernel.Rpc_error.raise e (Info.of_string "send request")
   in
-  let connected = Async_rpc_kernel.Persistent_connection.Rpc.connected conn in
-  match Deferred.peek connected with
-  | Some conn ->
-      handler conn
-  | None ->
-      upon connected handler
+  short_circuit handler
+    (Async_rpc_kernel.Persistent_connection.Rpc.connected conn)
 
 let do_action t (act : P.action) =
   match act with
   | `SendRequestVote (id, rv) ->
       send t id Types.RPCs.request_vote rv
+  | `SendRequestVoteResponse (id, rvr) ->
+      send t id Types.RPCs.request_vote_response rvr
   | `SendAppendEntries (id, ae) ->
       send t id Types.RPCs.append_entries ae
+  | `SendAppendEntriesResponse (id, aer) ->
+      send t id Types.RPCs.append_entries_response aer
   | `Unapplied cmds ->
       List.iter cmds ~f:(fun cmd -> return_result t cmd.id (Error `Unapplied))
   | `CommitIndexUpdate index ->
       advance_state_machine t index
-  | `SendRequestVoteResponse (id, rvr) ->
-      send t id Types.RPCs.request_vote_response rvr
-  | `SendAppendEntriesResponse (id, aer) ->
-      send t id Types.RPCs.append_entries_response aer
 
 let datasync =
   let sequencer = Throttle.Sequencer.create () in
   fun t ->
     Throttle.enqueue sequencer (fun () ->
         let%bind sync_index = MS.datasync t.store in
-        Pipe.write t.datasync_queue.wr sync_index)
+        Pipe.write_without_pushback t.datasync_queue.wr sync_index ;
+        Deferred.unit )
 
 let do_advance t event =
   let core, actions = P.advance t.core event |> get_ok in
   let core, store = P.pop_store core in
   t.core <- core ;
-  match MS.update t.store store with
-  | `SyncPossible when actions.nonblock_sync ->
-      datasync t |> Deferred.don't_wait_for ;
-      List.iter actions.acts ~f:(do_action t) ;
-      Deferred.unit
-  | `SyncPossible ->
-      let%bind () = datasync t in
-      List.iter actions.acts ~f:(do_action t) ;
-      Deferred.unit
-  | `NoSync ->
-      List.iter actions.acts ~f:(do_action t) ;
-      Deferred.unit
+  let%bind () =
+    match MS.update t.store store with
+    | `SyncPossible when not actions.nonblock_sync ->
+        datasync t
+    | `SyncPossible ->
+        datasync t |> Deferred.don't_wait_for ;
+        Deferred.unit
+    | `NoSync ->
+        Deferred.unit
+  in
+  List.iter actions.acts ~f:(do_action t) ;
+  Deferred.unit
 
 let server_impls =
-  Rpc.Implementations.create_exn ~on_unknown_rpc:`Continue
+  Rpc.Implementations.create_exn ~on_unknown_rpc:`Raise
     ~implementations:
       [ Rpc.One_way.implement RPCs.request_vote (fun q rv ->
-            Pipe.write_without_pushback q (`RRequestVote rv))
+            Pipe.write_without_pushback q (`RRequestVote rv) )
       ; Rpc.One_way.implement RPCs.request_vote_response (fun q rvr ->
-            Pipe.write_without_pushback q (`RRequestVoteResponse rvr))
+            Pipe.write_without_pushback q (`RRequestVoteResponse rvr) )
       ; Rpc.One_way.implement RPCs.append_entries (fun q ae ->
-            Pipe.write_without_pushback q (`RAppendEntries ae))
+            Pipe.write_without_pushback q (`RAppendEntries ae) )
       ; Rpc.One_way.implement RPCs.append_entries_response (fun q aer ->
-            Pipe.write_without_pushback q (`RAppendEntiresResponse aer)) ]
+            Pipe.write_without_pushback q (`RAppendEntiresResponse aer) ) ]
 
 let handle_ev_q t _window_size =
   let request_batch_pipe =
     Pipe.unfold ~init:() ~f:(fun () ->
         let%bind batch = get_request_batch t in
-        return (Some (batch, ())))
+        return (Some (batch, ())) )
   in
   let construct_choices () :
       [`Event of P.event | `Eof of string] Deferred.Choice.t list =
@@ -139,7 +138,7 @@ let handle_ev_q t _window_size =
         | `Eof ->
             `Eof "datasync"
         | `Ok idx ->
-            `Event (`Syncd idx))
+            `Event (`Syncd idx) )
     in
     let tickc =
       let read = Pipe.read_choice_single_consumer_exn t.tick_queue.rd [%here] in
@@ -147,7 +146,7 @@ let handle_ev_q t _window_size =
         | `Eof ->
             `Eof "tick"
         | `Ok `Tick ->
-            `Event `Tick)
+            `Event `Tick )
     in
     let evc =
       let read =
@@ -157,7 +156,7 @@ let handle_ev_q t _window_size =
         | `Eof ->
             `Eof "event"
         | `Ok v ->
-            `Event v)
+            `Event v )
     in
     let batchc =
       let read =
@@ -167,7 +166,7 @@ let handle_ev_q t _window_size =
         | `Eof ->
             `Eof "client-batching"
         | `Ok v ->
-            `Event (`Commands v))
+            `Event (`Commands v) )
     in
     [datasync_queue; tickc; evc; batchc]
   in
@@ -204,7 +203,7 @@ let create ~node_id ~node_list ~datadir ~external_port ~internal_port
       (batch_timeout : Time.Span.t)] ;
   let other_node_list =
     List.filter_map node_list ~f:(fun ((i, _) as x) ->
-        if Int.(i <> node_id) then Some x else None)
+        if Int.(i <> node_id) then Some x else None )
   in
   let config =
     let num_nodes = List.length node_list in
@@ -229,7 +228,7 @@ let create ~node_id ~node_list ~datadir ~external_port ~internal_port
   let _conn_state =
     H.iteri conns ~f:(fun ~key:id ~data:conn ->
         upon (Async_rpc_kernel.Persistent_connection.Rpc.connected conn)
-          (fun _ -> [%log.info logger "Connected to other node" (id : int)]))
+          (fun _ -> [%log.info logger "Connected to other node" (id : int)]) )
   in
   let state_machine = create_state_machine () in
   let event_queue =
@@ -252,12 +251,13 @@ let create ~node_id ~node_list ~datadir ~external_port ~internal_port
       (Tcp.Where_to_listen.of_port internal_port)
       ~on_handler_error:
         (`Call
-          (fun _ e -> [%log.error logger "Error while handling msg" (e : exn)]))
+          (fun _ e -> [%log.error logger "Error while handling msg" (e : exn)])
+          )
       (fun _addr reader writer ->
         Rpc.Connection.server_with_close reader writer
           ~implementations:server_impls
           ~connection_state:(fun _ -> event_queue.wr)
-          ~on_handshake_error:`Ignore)
+          ~on_handshake_error:`Ignore )
   in
   let t =
     { core
@@ -274,7 +274,7 @@ let create ~node_id ~node_list ~datadir ~external_port ~internal_port
   let log_window = 1 * batch_size in
   don't_wait_for (handle_ev_q t log_window) ;
   Async.every ~continue_on_error:true tick_speed (fun () ->
-      Pipe.write_without_pushback t.tick_queue.wr `Tick) ;
+      Pipe.write_without_pushback t.tick_queue.wr `Tick ) ;
   return t
 
 let close t =
@@ -282,4 +282,4 @@ let close t =
   and () = Tcp.Server.close t.internal_server in
   t.conns |> H.to_alist
   |> Deferred.List.iter ~how:`Parallel ~f:(fun (_, conn) ->
-         Async_rpc_kernel.Persistent_connection.Rpc.close conn)
+         Async_rpc_kernel.Persistent_connection.Rpc.close conn )

--- a/lib/infra.ml
+++ b/lib/infra.ml
@@ -9,7 +9,6 @@ module T = Types.Wal.Term
 open Types
 open Types.MessageTypes
 open! Utils
-open Core_profiler.Std_offline
 
 let debug_no_sync = false
 
@@ -19,23 +18,164 @@ let logger =
     ~transform:(fun m -> Message.add_tags m [("src", "Infra")])
     ()
 
-type ev_q =
-  { client_reqs: (client_request * Types.op_result Ivar.t) Queue.t
-  ; server_reqs: P.event Queue.t
-  ; server_resp: P.event Queue.t }
+type 'a rd_wr_pipe = {rd: 'a Pipe.Reader.t; wr: 'a Pipe.Writer.t}
+
+module ClientHandler = struct
+  open Rpc_parallel
+
+  module T = struct
+    (* Basic idea is that the main process contacts this one explicitly for a batch
+       We read that batch off of the cr_pipe.
+       When a request arrives we put it in that pipe.
+    *)
+    type request_batch = client_request list [@@deriving bin_io]
+
+    type return_result_t = command_id * client_response [@@deriving bin_io]
+
+    type 'a functions =
+      { get_batch: ('a, unit, request_batch) Function.t
+      ; return_result: ('a, return_result_t, unit) Function.t }
+
+    module Worker_state = struct
+      type init_arg =
+        {external_port: int; batch_size: int; batch_timeout: Time.Span.t}
+      [@@deriving bin_io]
+
+      type t =
+        { client_ivars: (command_id, client_response Ivar.t list) H.t
+        ; client_results: (command_id, op_result) H.t
+        ; cr_pipe: client_request rd_wr_pipe
+        ; batch_size: int
+        ; batch_timeout: Time.Span.t }
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+
+      type t = unit
+    end
+
+    module Functions
+        (C : Rpc_parallel.Creator
+               with type worker_state := Worker_state.t
+                and type connection_state := Connection_state.t) =
+    struct
+      open Worker_state
+
+      let client_handler_impl =
+        [ Rpc.Rpc.implement RPCs.client_request (fun t cr ->
+              [%log.debug logger "Received" (cr.id : Id.t)] ;
+              match H.find t.client_results cr.id with
+              | Some result ->
+                  return (Ok result)
+              | None ->
+                  Deferred.create (fun i ->
+                      H.add_multi t.client_ivars ~key:cr.id ~data:i ;
+                      Pipe.write_without_pushback t.cr_pipe.wr cr)) ]
+
+      let init_worker_state {external_port; batch_size; batch_timeout} =
+        let rd, wr = Pipe.create () in
+        let t =
+          { client_ivars= H.create (module Id)
+          ; client_results= H.create (module Id)
+          ; cr_pipe= {rd; wr}
+          ; batch_size
+          ; batch_timeout }
+        in
+        let implementations =
+          Rpc.Implementations.create_exn ~implementations:client_handler_impl
+            ~on_unknown_rpc:`Continue
+        in
+        let on_handler_error =
+          `Call
+            (fun _ e ->
+              [%log.error logger "Error while handling msg" (e : exn)])
+        in
+        let%bind (_ : (Socket.Address.Inet.t, int) Tcp.Server.t) =
+          Tcp.Server.create (Tcp.Where_to_listen.of_port external_port)
+            ~on_handler_error (fun _addr reader writer ->
+              Rpc.Connection.server_with_close reader writer ~implementations
+                ~connection_state:(fun _ -> t)
+                ~on_handshake_error:`Ignore)
+        in
+        return t
+
+      let init_connection_state ~connection:_ ~worker_state:_ () = Deferred.unit
+
+      let get_batch =
+        C.create_rpc ~name:"get_batch"
+          ~f:(fun ~worker_state:t ~conn_state:() () ->
+            match%bind Pipe.read t.cr_pipe.rd with
+            | `Eof ->
+                assert false
+            | `Ok fst ->
+                let batch = ref [fst] in
+                let rec loop rem =
+                  match%bind Pipe.read_exactly t.cr_pipe.rd ~num_values:rem with
+                  | `Eof ->
+                      assert false
+                  | `Exactly q ->
+                      Queue.iter q ~f:(fun v -> batch := v :: !batch) ;
+                      Deferred.unit
+                  | `Fewer q ->
+                      Queue.iter q ~f:(fun v -> batch := v :: !batch) ;
+                      loop (rem - Queue.length q)
+                in
+                let batch_gather = loop t.batch_size in
+                let batch_timout = after t.batch_timeout in
+                let%bind () =
+                  choose [choice batch_gather ignore; choice batch_timout ignore]
+                in
+                return !batch)
+          ~bin_input:bin_unit ~bin_output:bin_request_batch ()
+
+      let return_result =
+        C.create_one_way ~name:"return_results"
+          ~f:(fun ~worker_state:t ~conn_state:() (cmd_id, result) ->
+            ( match result with
+            | Error _ ->
+                ()
+            | Ok result ->
+                H.set t.client_results ~key:cmd_id ~data:result ) ;
+            let ivars = H.find_multi t.client_ivars cmd_id in
+            List.iter ivars ~f:(fun i -> Ivar.fill i result) ;
+            H.remove_multi t.client_ivars cmd_id)
+          ~bin_input:bin_return_result_t ()
+
+      let functions = {get_batch; return_result}
+    end
+  end
+
+  module M = Rpc_parallel.Make (T)
+  include M
+  module Shutdown_on = M.Shutdown_on (Monad.Ident)
+end
+
+module CH = ClientHandler
+
+let spawn_client_handler ~external_port ~batch_size ~batch_timeout =
+  let args = CH.T.Worker_state.{external_port; batch_size; batch_timeout} in
+  CH.spawn_exn ~shutdown_on:CH.Shutdown_on.Connection_closed
+    ~redirect_stdout:`Dev_null ~redirect_stderr:`Dev_null args
+    ~on_failure:Error.raise ~connection_state_init_arg:()
 
 type t =
   { mutable core: P.t
-  ; ev_q: ev_q
-  ; event_queue_bvar: (unit, read_write) Bvar.t
-  ; client_batch_size: int
-  ; mutable server: (Socket.Address.Inet.t, int) Tcp.Server.t Ivar.t
+  ; event_queue: P.event rd_wr_pipe
+  ; external_server: ClientHandler.Connection.t
+  ; internal_server: (Socket.Address.Inet.t, term) Tcp.Server.t
   ; wal: Wal.t
   ; mutable last_applied: log_index
   ; conns: (int, Async_rpc_kernel.Persistent_connection.Rpc.t) H.t
-  ; state_machine: state_machine
-  ; client_ivars: (command, client_response Ivar.t list) H.t
-  ; client_results: (command_id, op_result) H.t }
+  ; state_machine: state_machine }
+
+let get_request_batch t =
+  CH.Connection.run_exn t.external_server ~f:CH.functions.get_batch ~arg:()
+
+let return_result t id res =
+  CH.Connection.run_exn t.external_server ~f:CH.functions.return_result
+    ~arg:(id, res)
+  |> don't_wait_for
 
 let rec advance_state_machine t = function
   | commit_index when Int64.(t.last_applied < commit_index) ->
@@ -47,12 +187,7 @@ let rec advance_state_machine t = function
       t.last_applied <- index ;
       let entry = L.get_exn (P.get_log t.core) index in
       let result = update_state_machine t.state_machine entry.command in
-      H.set t.client_results ~key:entry.command.id ~data:result ;
-      let ivars = H.find_multi t.client_ivars entry.command in
-      List.iter ivars ~f:(fun ivar ->
-          [%log.debug
-            logger "Resolving" ((entry.command.id, index) : Id.t * int64)] ;
-          Ivar.fill_if_empty ivar result) ;
+      return_result t entry.command.id (Ok result) ;
       advance_state_machine t commit_index
   | _ ->
       ()
@@ -99,15 +234,11 @@ let do_post t post =
     | `SendAppendEntriesResponse (id, aer) ->
         send t id Types.RPCs.append_entries_response aer)
 
-let probe = Delta_timer.create ~name:"datasync"
-
 let do_actions t ((pre, do_sync, post) : P.action_sequence) =
   do_pre t pre ;
   match do_sync && not debug_no_sync with
   | true ->
-      let st = Delta_timer.stateless_start probe in
       let%map () = Wal.datasync t.wal in
-      Delta_timer.stateless_stop probe st ;
       do_post t post
   | false ->
       do_post t post |> return
@@ -117,126 +248,80 @@ let advance_wrapper t event =
   t.core <- core ;
   actions
 
-let enqueue t q v =
-  Queue.enqueue q v ;
-  Bvar.broadcast t.event_queue_bvar ()
-
 let server_impls =
-  [ Rpc.Rpc.implement RPCs.client_request (fun t cr ->
-        [%log.debug logger "Received" (cr.id : Id.t)] ;
-        match H.find t.client_results cr.id with
-        | Some result ->
-            return result
-        | None ->
-            Deferred.create (fun i -> enqueue t t.ev_q.client_reqs (cr, i)))
-  ; Rpc.One_way.implement RPCs.request_vote (fun t rv ->
-        enqueue t t.ev_q.server_reqs (`RRequestVote rv))
-  ; Rpc.One_way.implement RPCs.request_vote_response (fun t rvr ->
-        enqueue t t.ev_q.server_resp (`RRequestVoteResponse rvr))
-  ; Rpc.One_way.implement RPCs.append_entries (fun t ae ->
-        enqueue t t.ev_q.server_reqs (`RAppendEntries ae))
-  ; Rpc.One_way.implement RPCs.append_entries_response (fun t aer ->
-        enqueue t t.ev_q.server_resp (`RAppendEntiresResponse aer)) ]
-
-let deque_n q n =
-  let rec loop (acc, i) n =
-    match n with
-    | 0 ->
-        (acc, i)
-    | _ when Queue.length q = 0 ->
-        (acc, i)
-    | n ->
-        loop (Queue.dequeue_exn q :: acc, i + 1) (n - 1)
-  in
-  let xs, l = loop ([], 0) n in
-  (List.rev xs, l)
-
-let%expect_test "dequeue_n" =
-  let q = Queue.of_list [1; 2; 3; 4] in
-  deque_n q 3 |> [%sexp_of: int list * int] |> Sexp.to_string_hum
-  |> print_endline ;
-  [%expect {| (1 2 3) |}]
-
-let batch_probe = Probe.create ~name:"Batch_size" ~units:Profiler_units.Int
+  Rpc.Implementations.create_exn ~on_unknown_rpc:`Continue
+    ~implementations:
+      [ Rpc.One_way.implement RPCs.request_vote (fun q rv ->
+            Pipe.write_without_pushback q (`RRequestVote rv))
+      ; Rpc.One_way.implement RPCs.request_vote_response (fun q rvr ->
+            Pipe.write_without_pushback q (`RRequestVoteResponse rvr))
+      ; Rpc.One_way.implement RPCs.append_entries (fun q ae ->
+            Pipe.write_without_pushback q (`RAppendEntries ae))
+      ; Rpc.One_way.implement RPCs.append_entries_response (fun q aer ->
+            Pipe.write_without_pushback q (`RAppendEntiresResponse aer)) ]
 
 let handle_ev_q t =
-  let batch_counter = ref 0 in
-  let batching_freq = 2 in
+  let request_batch_pipe =
+    Pipe.unfold ~init:() ~f:(fun () ->
+        let%bind batch = get_request_batch t in
+        return (Some (batch, ())))
+  in
+  let construct_choices () =
+    let evq =
+      let open Deferred.Choice in
+      let read =
+        Pipe.read_choice_single_consumer_exn t.event_queue.rd [%here]
+      in
+      map read ~f:(function `Eof -> assert false | `Ok v -> `Event v)
+    in
+    let batchq =
+      let open Deferred.Choice in
+      let read =
+        Pipe.read_choice_single_consumer_exn request_batch_pipe [%here]
+      in
+      map read ~f:(function `Eof -> assert false | `Ok v -> `Batch v)
+    in
+    [evq; batchq]
+  in
   let rec loop () =
     let run_queues () =
-      match () with
-      | () when Queue.length t.ev_q.server_resp > 0 ->
-          let event = Queue.dequeue_exn t.ev_q.server_resp in
-          event |> advance_wrapper t |> do_actions t
-      | () when Queue.length t.ev_q.server_reqs > 0 ->
-          let event = Queue.dequeue_exn t.ev_q.server_reqs in
-          event |> advance_wrapper t |> do_actions t
-      | ()
-        when Queue.length t.ev_q.client_reqs >= t.client_batch_size
-             || !batch_counter >= batching_freq ->
-          if !batch_counter >= batching_freq then batch_counter := 0 ;
-          let batch, batch_size =
-            deque_n t.ev_q.client_reqs t.client_batch_size
-          in
-          Probe.record batch_probe batch_size ;
+      match%bind choose @@ construct_choices () with
+      | `Event e ->
+          e |> advance_wrapper t |> do_actions t
+      | `Batch batch ->
+          let batch_size = List.length batch in
           [%log.debug logger (batch_size : int)] ;
-          let htbl = H.of_alist_exn (module Types.Command) batch in
-          let ((pre, _, _) as actions) =
-            advance_wrapper t (`Commands (List.map batch ~f:fst))
+          let ((pre, _, _) as actions) = advance_wrapper t (`Commands batch) in
+          let unapplied =
+            List.filter_map pre ~f:(function
+              | `Unapplied _ as v ->
+                  Some v
+              | _ ->
+                  None)
           in
-          let () =
-            match
-              List.find_map pre ~f:(function
-                | `Unapplied _ as v ->
-                    Some v
-                | _ ->
-                    None)
-            with
-            | Some (`Unapplied cmds) ->
-                List.iter cmds ~f:(fun cmd ->
-                    let ivar = H.find_exn htbl cmd in
-                    Ivar.fill ivar Types.Failure)
-            | None ->
-                ()
-          in
-          List.iter batch ~f:(fun (cmd, ivar) ->
-              if Ivar.is_empty ivar then
-                H.add_multi t.client_ivars ~key:cmd ~data:ivar) ;
+          List.iter unapplied ~f:(fun (`Unapplied cmds) ->
+              List.iter cmds ~f:(fun cmd ->
+                  return_result t cmd.id (Error `Unapplied))) ;
           do_actions t actions
-      | () ->
-          incr batch_counter ; return ()
-    in
-    let%bind () =
-      match
-        Queue.length t.ev_q.server_resp
-        + Queue.length t.ev_q.server_reqs
-        + Queue.length t.ev_q.client_reqs
-      with
-      | 0 ->
-          Bvar.wait t.event_queue_bvar
-      | _ ->
-          return ()
     in
     let%bind () = run_queues () in
-    let%bind () =
-      Scheduler.yield_until_no_jobs_remain ~may_return_immediately:true ()
-    in
     loop ()
   in
   loop ()
 
-let create ~node_id ~node_list ~datadir ~listen_port ~election_timeout
-    ~tick_speed ~batch_size ~dispatch_timeout =
+let create ~node_id ~node_list ~datadir ~external_port ~internal_port
+    ~election_timeout ~tick_speed ~batch_size ~batch_timeout =
   [%log.debug
     logger "Input parameters"
       (node_id : int)
       (node_list : (int * string) list)
       (datadir : string)
-      (listen_port : int)
+      (external_port : int)
+      (internal_port : int)
       (election_timeout : int)
       (tick_speed : Time.Span.t)
       (batch_size : int)
-      (dispatch_timeout : Time.Span.t)] ;
+      (batch_timeout : Time.Span.t)] ;
   let other_node_list =
     List.filter_map node_list ~f:(fun ((i, _) as x) ->
         if Int.(i <> node_id) then Some x else None)
@@ -262,48 +347,43 @@ let create ~node_id ~node_list ~datadir ~listen_port ~election_timeout
     |> H.of_alist_exn (module Int)
   in
   let state_machine = create_state_machine () in
-  let t_ivar = Ivar.create () in
-  let server_ivar = Ivar.create () in
+  let event_queue =
+    let rd, wr = Pipe.create () in
+    {rd; wr}
+  in
+  let%bind external_server =
+    spawn_client_handler ~external_port ~batch_size ~batch_timeout
+  in
+  let%bind internal_server =
+    Tcp.Server.create
+      (Tcp.Where_to_listen.of_port external_port)
+      ~on_handler_error:
+        (`Call
+          (fun _ e -> [%log.error logger "Error while handling msg" (e : exn)]))
+      (fun _addr reader writer ->
+        Rpc.Connection.server_with_close reader writer
+          ~implementations:server_impls
+          ~connection_state:(fun _ -> event_queue.wr)
+          ~on_handshake_error:`Ignore)
+  in
   let t =
     { core
-    ; ev_q=
-        { client_reqs= Queue.create ()
-        ; server_reqs= Queue.create ()
-        ; server_resp= Queue.create () }
-    ; event_queue_bvar= Bvar.create ()
-    ; client_batch_size= batch_size
-    ; server= server_ivar
+    ; event_queue
+    ; external_server
+    ; internal_server
     ; wal
     ; last_applied= Int64.zero
     ; conns
-    ; state_machine
-    ; client_ivars= H.create (module Types.Command)
-    ; client_results= H.create (module Types.Id) }
+    ; state_machine }
   in
-  Ivar.fill t_ivar t ;
   don't_wait_for (handle_ev_q t) ;
   Async.every ~continue_on_error:true tick_speed (fun () ->
       advance_wrapper t `Tick |> do_actions t |> don't_wait_for) ;
-  let implementations =
-    Rpc.Implementations.create_exn ~implementations:server_impls
-      ~on_unknown_rpc:`Continue
-  in
-  let on_handler_error =
-    `Call (fun _ e -> [%log.error logger "Error while handling msg" (e : exn)])
-  in
-  let server =
-    Tcp.Server.create (Tcp.Where_to_listen.of_port listen_port)
-      ~on_handler_error (fun _addr reader writer ->
-        Rpc.Connection.server_with_close reader writer ~implementations
-          ~connection_state:(fun _ -> t)
-          ~on_handshake_error:`Ignore)
-  in
-  upon server (fun server -> Ivar.fill server_ivar server) ;
   return t
 
 let close t =
-  let%bind server = Ivar.read t.server in
-  let%bind () = Tcp.Server.close server in
-  t.conns |> H.to_alist |> List.map ~f:snd
-  |> Deferred.List.iter ~how:`Parallel ~f:(fun conn ->
+  let%bind () = ClientHandler.Connection.close t.external_server
+  and () = Tcp.Server.close t.internal_server in
+  t.conns |> H.to_alist
+  |> Deferred.List.iter ~how:`Parallel ~f:(fun (_, conn) ->
          Async_rpc_kernel.Persistent_connection.Rpc.close conn)

--- a/lib/infra.ml
+++ b/lib/infra.ml
@@ -6,9 +6,9 @@ module O = Owal
 module H = Hashtbl
 module L = Types.Wal.Log
 module T = Types.Wal.Term
+module CH = Client_handler
 open Types
-open Types.MessageTypes
-open! Utils
+open Utils
 
 let debug_no_sync = false
 
@@ -18,151 +18,11 @@ let logger =
     ~transform:(fun m -> Message.add_tags m [("src", "Infra")])
     ()
 
-type 'a rd_wr_pipe = {rd: 'a Pipe.Reader.t; wr: 'a Pipe.Writer.t}
-
-module ClientHandler = struct
-  open Rpc_parallel
-
-  module T = struct
-    (* Basic idea is that the main process contacts this one explicitly for a batch
-       We read that batch off of the cr_pipe.
-       When a request arrives we put it in that pipe.
-    *)
-    type request_batch = client_request list [@@deriving bin_io]
-
-    type return_result_t = command_id * client_response [@@deriving bin_io]
-
-    type 'a functions =
-      { get_batch: ('a, unit, request_batch) Function.t
-      ; return_result: ('a, return_result_t, unit) Function.t }
-
-    module Worker_state = struct
-      type init_arg =
-        {external_port: int; batch_size: int; batch_timeout: Time.Span.t}
-      [@@deriving bin_io]
-
-      type t =
-        { client_ivars: (command_id, client_response Ivar.t list) H.t
-        ; client_results: (command_id, op_result) H.t
-        ; cr_pipe: client_request rd_wr_pipe
-        ; batch_size: int
-        ; batch_timeout: Time.Span.t }
-    end
-
-    module Connection_state = struct
-      type init_arg = unit [@@deriving bin_io]
-
-      type t = unit
-    end
-
-    module Functions
-        (C : Rpc_parallel.Creator
-               with type worker_state := Worker_state.t
-                and type connection_state := Connection_state.t) =
-    struct
-      open Worker_state
-
-      let client_handler_impl =
-        [ Rpc.Rpc.implement RPCs.client_request (fun t cr ->
-              [%log.debug logger "Received" (cr.id : Id.t)] ;
-              match H.find t.client_results cr.id with
-              | Some result ->
-                  return (Ok result)
-              | None ->
-                  Deferred.create (fun i ->
-                      H.add_multi t.client_ivars ~key:cr.id ~data:i ;
-                      Pipe.write_without_pushback t.cr_pipe.wr cr)) ]
-
-      let init_worker_state {external_port; batch_size; batch_timeout} =
-        let rd, wr = Pipe.create () in
-        let t =
-          { client_ivars= H.create (module Id)
-          ; client_results= H.create (module Id)
-          ; cr_pipe= {rd; wr}
-          ; batch_size
-          ; batch_timeout }
-        in
-        let implementations =
-          Rpc.Implementations.create_exn ~implementations:client_handler_impl
-            ~on_unknown_rpc:`Continue
-        in
-        let on_handler_error =
-          `Call
-            (fun _ e ->
-              [%log.error logger "Error while handling msg" (e : exn)])
-        in
-        let%bind (_ : (Socket.Address.Inet.t, int) Tcp.Server.t) =
-          Tcp.Server.create (Tcp.Where_to_listen.of_port external_port)
-            ~on_handler_error (fun _addr reader writer ->
-              Rpc.Connection.server_with_close reader writer ~implementations
-                ~connection_state:(fun _ -> t)
-                ~on_handshake_error:`Ignore)
-        in
-        return t
-
-      let init_connection_state ~connection:_ ~worker_state:_ () = Deferred.unit
-
-      let get_batch =
-        C.create_rpc ~name:"get_batch"
-          ~f:(fun ~worker_state:t ~conn_state:() () ->
-            match%bind Pipe.read t.cr_pipe.rd with
-            | `Eof ->
-                assert false
-            | `Ok fst ->
-                let batch = ref [fst] in
-                let rec loop rem =
-                  match%bind Pipe.read_exactly t.cr_pipe.rd ~num_values:rem with
-                  | `Eof ->
-                      assert false
-                  | `Exactly q ->
-                      Queue.iter q ~f:(fun v -> batch := v :: !batch) ;
-                      Deferred.unit
-                  | `Fewer q ->
-                      Queue.iter q ~f:(fun v -> batch := v :: !batch) ;
-                      loop (rem - Queue.length q)
-                in
-                let batch_gather = loop t.batch_size in
-                let batch_timout = after t.batch_timeout in
-                let%bind () =
-                  choose [choice batch_gather ignore; choice batch_timout ignore]
-                in
-                return !batch)
-          ~bin_input:bin_unit ~bin_output:bin_request_batch ()
-
-      let return_result =
-        C.create_one_way ~name:"return_results"
-          ~f:(fun ~worker_state:t ~conn_state:() (cmd_id, result) ->
-            ( match result with
-            | Error _ ->
-                ()
-            | Ok result ->
-                H.set t.client_results ~key:cmd_id ~data:result ) ;
-            let ivars = H.find_multi t.client_ivars cmd_id in
-            List.iter ivars ~f:(fun i -> Ivar.fill i result) ;
-            H.remove_multi t.client_ivars cmd_id)
-          ~bin_input:bin_return_result_t ()
-
-      let functions = {get_batch; return_result}
-    end
-  end
-
-  module M = Rpc_parallel.Make (T)
-  include M
-  module Shutdown_on = M.Shutdown_on (Monad.Ident)
-end
-
-module CH = ClientHandler
-
-let spawn_client_handler ~external_port ~batch_size ~batch_timeout =
-  let args = CH.T.Worker_state.{external_port; batch_size; batch_timeout} in
-  CH.spawn_exn ~shutdown_on:CH.Shutdown_on.Connection_closed
-    ~redirect_stdout:`Dev_null ~redirect_stderr:`Dev_null args
-    ~on_failure:Error.raise ~connection_state_init_arg:()
-
 type t =
   { mutable core: P.t
   ; event_queue: P.event rd_wr_pipe
-  ; external_server: ClientHandler.Connection.t
+  ; tick_queue: [`Tick] rd_wr_pipe
+  ; external_server: CH.Connection.t
   ; internal_server: (Socket.Address.Inet.t, term) Tcp.Server.t
   ; wal: Wal.t
   ; mutable last_applied: log_index
@@ -260,28 +120,42 @@ let server_impls =
       ; Rpc.One_way.implement RPCs.append_entries_response (fun q aer ->
             Pipe.write_without_pushback q (`RAppendEntiresResponse aer)) ]
 
-let handle_ev_q t =
+let handle_ev_q t window_size =
   let request_batch_pipe =
     Pipe.unfold ~init:() ~f:(fun () ->
         let%bind batch = get_request_batch t in
         return (Some (batch, ())))
   in
   let construct_choices () =
-    let evq =
-      let open Deferred.Choice in
+    let ( let+ ) v f = v @ f () in
+    let+ (_tickq : unit) =
+      let read = Pipe.read_choice_single_consumer_exn t.tick_queue.rd [%here] in
+      let f = function `Eof -> assert false | `Ok `Tick -> `Event `Tick in
+      [Deferred.Choice.map read ~f]
+    in
+    let+ (_evq : unit) =
       let read =
         Pipe.read_choice_single_consumer_exn t.event_queue.rd [%here]
       in
-      map read ~f:(function `Eof -> assert false | `Ok v -> `Event v)
+      let f = function `Eof -> assert false | `Ok v -> `Event v in
+      [Deferred.Choice.map read ~f]
     in
-    let batchq =
-      let open Deferred.Choice in
-      let read =
-        Pipe.read_choice_single_consumer_exn request_batch_pipe [%here]
-      in
-      map read ~f:(function `Eof -> assert false | `Ok v -> `Batch v)
+    let+ (_batchq : unit) =
+      match () with
+      | ()
+        when Int64.(to_int_exn @@ (P.get_max_index t.core - t.last_applied))
+             > window_size ->
+          (* Don't read from external pipe if there are many outstanding requests *)
+          []
+      | () ->
+          let read =
+            Pipe.read_choice_single_consumer_exn request_batch_pipe [%here]
+          in
+          let f = function `Eof -> assert false | `Ok v -> `Batch v in
+          [Deferred.Choice.map read ~f]
     in
-    [evq; batchq]
+    (* Return [] in order to build up list from this *)
+    []
   in
   let rec loop () =
     let run_queues () =
@@ -351,12 +225,16 @@ let create ~node_id ~node_list ~datadir ~external_port ~internal_port
     let rd, wr = Pipe.create () in
     {rd; wr}
   in
+  let tick_queue =
+    let rd, wr = Pipe.create () in
+    {rd; wr}
+  in
   let%bind external_server =
-    spawn_client_handler ~external_port ~batch_size ~batch_timeout
+    CH.spawn_client_handler ~external_port ~batch_size ~batch_timeout
   in
   let%bind internal_server =
     Tcp.Server.create
-      (Tcp.Where_to_listen.of_port external_port)
+      (Tcp.Where_to_listen.of_port internal_port)
       ~on_handler_error:
         (`Call
           (fun _ e -> [%log.error logger "Error while handling msg" (e : exn)]))
@@ -369,6 +247,7 @@ let create ~node_id ~node_list ~datadir ~external_port ~internal_port
   let t =
     { core
     ; event_queue
+    ; tick_queue
     ; external_server
     ; internal_server
     ; wal
@@ -376,13 +255,14 @@ let create ~node_id ~node_list ~datadir ~external_port ~internal_port
     ; conns
     ; state_machine }
   in
-  don't_wait_for (handle_ev_q t) ;
+  let log_window = 1 * batch_size in
+  don't_wait_for (handle_ev_q t log_window) ;
   Async.every ~continue_on_error:true tick_speed (fun () ->
-      advance_wrapper t `Tick |> do_actions t |> don't_wait_for) ;
+      Pipe.write_without_pushback t.tick_queue.wr `Tick) ;
   return t
 
 let close t =
-  let%bind () = ClientHandler.Connection.close t.external_server
+  let%bind () = CH.Connection.close t.external_server
   and () = Tcp.Server.close t.internal_server in
   t.conns |> H.to_alist
   |> Deferred.List.iter ~how:`Parallel ~f:(fun (_, conn) ->

--- a/lib/infra.ml
+++ b/lib/infra.ml
@@ -35,9 +35,12 @@ let batch_available_watch t =
     ~arg:()
 
 let p_cr_len = Probe.create ~name:"cr_len" ~units:Profiler_units.Int
+
 let get_request_batch t =
-  let%bind batch, cr_len = CH.Connection.run_exn t.external_server ~f:CH.functions.get_batch ~arg:() in
-  Probe.record p_cr_len cr_len;
+  let%bind batch, cr_len =
+    CH.Connection.run_exn t.external_server ~f:CH.functions.get_batch ~arg:()
+  in
+  Probe.record p_cr_len cr_len ;
   return batch
 
 let return_result t id res =

--- a/lib/infra.mli
+++ b/lib/infra.mli
@@ -9,11 +9,12 @@ val create :
      node_id:int
   -> node_list:(int * string) list
   -> datadir:string
-  -> listen_port:int
+  -> external_port:int
+  -> internal_port:int
   -> election_timeout:int
   -> tick_speed:Time.Span.t
   -> batch_size:int
-  -> dispatch_timeout:Core.Time.Span.t
+  -> batch_timeout:Time.Span.t
   -> t Deferred.t
 (** [create] returns a new node after it has loaded its state from file.
     [node_list] is a list of pairs of node_ids and addresses (eg 127.0.0.1:5001)

--- a/lib/owal.ml
+++ b/lib/owal.ml
@@ -146,7 +146,7 @@ module Persistant (P : Persistable) = struct
             | Error `Closed ->
                 assert false
             | Ok () ->
-                return ())
+                return () )
         |> don't_wait_for
     | `Closed ->
         raise Closed
@@ -163,7 +163,7 @@ module Persistant (P : Persistable) = struct
           in
           Ivar.fill ivar () |> return
         in
-        p |> don't_wait_for |> return)
+        p |> don't_wait_for |> return )
     |> don't_wait_for ;
     Ivar.read ivar
 
@@ -182,7 +182,7 @@ module Persistant (P : Persistable) = struct
             U.accumulate t.file_closure_chain curr |> don't_wait_for ;
             let%bind () = U.accumulate t.file_closure_chain next in
             Throttle.kill t.serialisation ;
-            return ())
+            return () )
 
   let of_path ?(file_size = Int64.((of_int 2 ** of_int 20) * of_int 128)) path =
     let%bind _create_dir_if_needed =

--- a/lib/owal.ml
+++ b/lib/owal.ml
@@ -12,7 +12,7 @@ module type Persistable = sig
 
   val init : unit -> t
 
-  type op [@@deriving bin_io]
+  type op [@@deriving bin_io, sexp]
 
   val apply : t -> op -> t
 end

--- a/lib/owal.mli
+++ b/lib/owal.mli
@@ -8,7 +8,7 @@ module type Persistable = sig
 
   val init : unit -> t
 
-  type op [@@deriving bin_io]
+  type op [@@deriving bin_io,sexp]
 
   val apply : t -> op -> t
 end

--- a/lib/owal.mli
+++ b/lib/owal.mli
@@ -8,7 +8,7 @@ module type Persistable = sig
 
   val init : unit -> t
 
-  type op [@@deriving bin_io,sexp]
+  type op [@@deriving bin_io, sexp]
 
   val apply : t -> op -> t
 end

--- a/lib/paxos_core.ml
+++ b/lib/paxos_core.ml
@@ -496,6 +496,8 @@ let is_leader t =
 
 let get_log (t : t) = t.log
 
+let get_max_index (t : t) = L.get_max_index t.log
+
 let get_term (t : t) = t.current_term
 
 let create_node config log current_term =

--- a/lib/paxos_core.ml
+++ b/lib/paxos_core.ml
@@ -246,6 +246,8 @@ module ReplicationSM = struct
         let prev_log_index = Int64.(next_index - one) in
         let entries = S.entries_after_inc t.store next_index in
         let entries_length = List.length entries |> Int64.of_int in
+        let%bind () = StateR.map_t @@ A.map (node_state @> Leader.next_index) ~f:(Map.set ~key:dst ~data:Int64.(next_index + entries_length)) in
+        let%bind t = StateR.get_t () in
         [%log.debug
           logger (dst : int) (next_index : int64) (entries_length : int64)] ;
         match entries with

--- a/lib/paxos_core.ml
+++ b/lib/paxos_core.ml
@@ -150,7 +150,6 @@ module State = struct
 
   let appendv actions state =
     ((), A.map (a @> acts) ~f:(List.append actions) state)
-
 end
 
 module StateR = struct
@@ -250,7 +249,12 @@ module ReplicationSM = struct
         let prev_log_index = Int64.(next_index - one) in
         let entries = S.entries_after_inc t.store next_index in
         let entries_length = List.length entries |> Int64.of_int in
-        let%bind () = StateR.map_t @@ A.map (node_state @> Leader.next_index) ~f:(Map.set ~key:dst ~data:Int64.(next_index + entries_length)) in
+        let%bind () =
+          StateR.map_t
+          @@ A.map
+               (node_state @> Leader.next_index)
+               ~f:(Map.set ~key:dst ~data:Int64.(next_index + entries_length))
+        in
         let%bind t = StateR.get_t () in
         Probe.record probe_send_size (Int64.to_int_exn entries_length) ;
         [%log.debug
@@ -520,14 +524,14 @@ let rec advance_raw (event : event) : (unit, 'b) StateR.t =
       let%bind () = transition_to_follower () in
       advance_raw event
   | `RRequestVote msg, _ when Int.(msg.term < S.get_current_term t.store) ->
-        StateR.append
-        @@ `SendRequestVoteResponse
-             ( msg.src
-             , { src= t.config.node_id
-               ; term= S.get_current_term t.store
-               ; vote_granted= false
-               ; entries= []
-               ; start_index= Int64.(msg.leader_commit + one) } )
+      StateR.append
+      @@ `SendRequestVoteResponse
+           ( msg.src
+           , { src= t.config.node_id
+             ; term= S.get_current_term t.store
+             ; vote_granted= false
+             ; entries= []
+             ; start_index= Int64.(msg.leader_commit + one) } )
   | `RRequestVote msg, _ ->
       let%bind () =
         StateR.append
@@ -591,15 +595,17 @@ let rec advance_raw (event : event) : (unit, 'b) StateR.t =
         List.filter cs ~f:(fun cmd -> not @@ S.mem_id t.store cmd.id)
       in
       Probe.record command_size_probe (List.length cmds) ;
-      let%bind () = StateR.map_t @@ A.map store ~f:(S.add_cmds ~cmds ~term:(S.get_current_term t.store)) in
+      let%bind () =
+        StateR.map_t
+        @@ A.map store ~f:(S.add_cmds ~cmds ~term:(S.get_current_term t.store))
+      in
       let%bind () = check_commit_index () in
-        StateR.list_iter t.config.other_nodes
-          ~f:(ReplicationSM.send_append_entries)
+      StateR.list_iter t.config.other_nodes ~f:ReplicationSM.send_append_entries
   | `Commands cs, _ ->
-    StateR.append (`Unapplied cs)
+      StateR.append (`Unapplied cs)
   | `Syncd index, _ ->
-    let%bind () = recv_syncd index in
-    check_commit_index ()
+      let%bind () = recv_syncd index in
+      check_commit_index ()
 
 let is_leader (t : t) =
   match t.node_state with
@@ -617,7 +623,9 @@ let pop_store (t : t) = ({t with store= S.reset_ops t.store}, t.store)
 let advance t event =
   [%log.debug io_logger "Entry" (event : event)] ;
   let prog = advance_raw event in
-  let%bind.Result (), State.{t; a=actions} = StateR.eval prog (State.empty t) in
+  let%bind.Result (), State.{t; a= actions} =
+    StateR.eval prog (State.empty t)
+  in
   let is_leader = Option.is_some (is_leader t) in
   let actions =
     {actions with nonblock_sync= actions.nonblock_sync || is_leader}

--- a/lib/paxos_core.mli
+++ b/lib/paxos_core.mli
@@ -38,8 +38,7 @@ type action_sequence = pre_sync_action list * do_sync * post_sync_action list
 val pp_action :
   Format.formatter -> [< pre_sync_action | post_sync_action] -> unit
 
-val pp_event :
-  Format.formatter -> event -> unit
+val pp_event : Format.formatter -> event -> unit
 
 type config =
   { phase1majority: int

--- a/lib/paxos_core.mli
+++ b/lib/paxos_core.mli
@@ -71,19 +71,27 @@ val pop_store : t -> t * S.t
 
 (** Module for testing internal state *)
 module Test : sig
-  module Comp : sig
-    type 'a t = 'a * actions
+
+  module State : sig
+    type state = {t : t; a : actions}
+    val empty : t -> state
+  end 
+
+  module StateR : sig
+    type ('a, 'b) t
+    val eval : ('a, 'b) t -> State.state -> ('a * State.state, 'b) result
+    module Let_syntax : sig
+      module Let_syntax : sig
+        val bind : ('a, 'b) t -> f:('a -> ('c, 'b) t) -> ('c, 'b) t
+      end 
+    end 
   end
 
-  module CompRes : sig
-    type ('a, 'b) t = ('a Comp.t, 'b) Result.t
-  end
+  val transition_to_leader : unit -> (unit, [> `Msg of string]) StateR.t
 
-  val transition_to_leader : t -> (t, [> `Msg of string]) CompRes.t
+  val transition_to_candidate : unit -> (unit, [> `Msg of string]) StateR.t
 
-  val transition_to_candidate : t -> (t, [> `Msg of string]) CompRes.t
-
-  val transition_to_follower : t -> (t, [> `Msg of string]) CompRes.t
+  val transition_to_follower : unit -> (unit, [> `Msg of string]) StateR.t
 
   val get_node_state : t -> node_state
 

--- a/lib/paxos_core.mli
+++ b/lib/paxos_core.mli
@@ -4,6 +4,9 @@ module S = IStorage
 
 val logger : Async.Log.t
 
+(* More verbose logging for entry and exit of module *)
+val io_logger : Async.Log.t
+
 (** All the events incomming into the advance function *)
 type event =
   [ `Tick

--- a/lib/paxos_core.mli
+++ b/lib/paxos_core.mli
@@ -66,6 +66,8 @@ val advance : t -> event -> (t * action_sequence, [> `Msg of string]) result
 
 val get_log : t -> Types.log
 
+val get_max_index : t -> log_index
+
 val get_term : t -> Types.term
 
 (** Module for testing internal state *)

--- a/lib/paxos_core.mli
+++ b/lib/paxos_core.mli
@@ -71,20 +71,22 @@ val pop_store : t -> t * S.t
 
 (** Module for testing internal state *)
 module Test : sig
-
   module State : sig
-    type state = {t : t; a : actions}
+    type state = {t: t; a: actions}
+
     val empty : t -> state
-  end 
+  end
 
   module StateR : sig
     type ('a, 'b) t
+
     val eval : ('a, 'b) t -> State.state -> ('a * State.state, 'b) result
+
     module Let_syntax : sig
       module Let_syntax : sig
         val bind : ('a, 'b) t -> f:('a -> ('c, 'b) t) -> ('c, 'b) t
-      end 
-    end 
+      end
+    end
   end
 
   val transition_to_leader : unit -> (unit, [> `Msg of string]) StateR.t

--- a/lib/paxos_core.mli
+++ b/lib/paxos_core.mli
@@ -23,17 +23,17 @@ type pre_sync_action =
   [ `PersistantChange of persistant_change
   | `SendRequestVote of node_id * request_vote
   | `SendAppendEntries of node_id * append_entries
-  | `Unapplied of command list ]
+  | `Unapplied of command list ] [@@deriving sexp]
 
 type post_sync_action =
   [ `SendRequestVoteResponse of node_id * request_vote_response
   | `SendAppendEntriesResponse of node_id * append_entries_response
-  | `CommitIndexUpdate of log_index ]
+  | `CommitIndexUpdate of log_index ][@@deriving sexp]
 
-type do_sync = bool
+type do_sync = bool [@@deriving sexp]
 
 (** Return type of advance, post_sync actions must be done after the persistant state is stored to disk *)
-type action_sequence = pre_sync_action list * do_sync * post_sync_action list
+type action_sequence = pre_sync_action list * do_sync * post_sync_action list [@@deriving sexp]
 
 val pp_action :
   Format.formatter -> [< pre_sync_action | post_sync_action] -> unit

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -91,7 +91,7 @@ module ILog = struct
       let removed, store = List.split_n t.store (Int64.to_int_exn drop) in
       let command_set =
         List.fold_left removed ~init:t.command_set ~f:(fun cset entry ->
-            Set.remove cset entry.command.id)
+            Set.remove cset entry.command.id )
       in
       let length = Int64.(max zero (t.length - drop)) in
       {store; command_set; length}
@@ -186,7 +186,7 @@ module ILog = struct
     let t, ops =
       List.fold_left entries_to_add ~init:(t, ops) ~f:(fun (t, ops) v ->
           let t', ops' = apply_wrap t (Add v) in
-          (t', ops' :: ops))
+          (t', ops' :: ops) )
     in
     (t, ops)
 
@@ -196,7 +196,7 @@ module ILog = struct
     List.fold cmds ~init:(t, []) ~f:(fun (t, ops) command ->
         let t, op = add_cmd t command term in
         let ops = op :: ops in
-        (t, ops))
+        (t, ops) )
 end
 
 module ITerm = struct

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -62,11 +62,11 @@ type log_entry = {command: command; term: term} [@@deriving bin_io, sexp]
 module Wal = struct
   module Term = struct
     module T = struct
-      type t = term [@@deriving bin_io]
+      type t = term [@@deriving bin_io, sexp]
 
       let init () = 0
 
-      type op = t [@@deriving bin_io]
+      type op = t [@@deriving bin_io, sexp]
 
       let apply _t op = op
     end
@@ -89,7 +89,7 @@ module Wal = struct
 
       let init () = {store= []; command_set= IdSet.empty; length= Int64.zero}
 
-      type op = Add of log_entry | RemoveGEQ of log_index [@@deriving bin_io]
+      type op = Add of log_entry | RemoveGEQ of log_index [@@deriving bin_io, sexp]
 
       let add t entry =
         let command_set = Set.add t.command_set entry.command.id in
@@ -116,7 +116,7 @@ module Wal = struct
 
     type t = L.t [@@deriving sexp]
 
-    type op = L.op
+    type op = L.op [@@deriving bin_io,sexp]
 
     let get (t : L.t) index =
       let nth = L.nth_of_index t index |> Int64.to_int_exn in
@@ -217,7 +217,7 @@ module Wal = struct
 
     let init () = {term= Term.init (); log= Log.L.init ()}
 
-    type op = Term of Term.T.op | Log of Log.L.op [@@deriving bin_io]
+    type op = Term of Term.T.op | Log of Log.L.op [@@deriving bin_io, sexp]
 
     let apply t = function
       | Term op ->

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1,6 +1,8 @@
 open! Core
 open! Async
 open! Ppx_log_async
+module A = Accessor_async
+open! A.O
 
 let logger =
   let open Async_unix.Log in
@@ -14,29 +16,30 @@ type node_addr = string
 
 module Id = Unique_id.Int63 ()
 
-type command_id = Id.t [@@deriving bin_io, sexp]
+type command_id = Id.t [@@deriving bin_io, sexp, compare]
 
 type client_id = Id.t [@@deriving bin_io, sexp]
 
 type node_id = int [@@deriving bin_io, sexp]
 
-type key = string [@@deriving bin_io, sexp]
+type key = string [@@deriving bin_io, sexp, compare]
 
-type value = string [@@deriving bin_io, sexp]
+type value = string [@@deriving bin_io, sexp, compare]
 
 type state_machine = (key, value) Hashtbl.t
 
-type op = Read of key | Write of key * value [@@deriving bin_io, sexp]
+type sm_op = Read of key | Write of key * value
+[@@deriving bin_io, sexp, compare]
 
 module Command = struct
-  type t = {op: op; id: command_id} [@@deriving bin_io, sexp]
+  type t = {op: sm_op; id: command_id} [@@deriving bin_io, sexp, compare]
 
   let compare a b = Id.compare a.id b.id
 
   let hash t = Id.hash t.id
 end
 
-type command = Command.t [@@deriving bin_io, sexp]
+type command = Command.t [@@deriving bin_io, sexp, compare]
 
 type op_result = Success | Failure | ReadSuccess of key
 [@@deriving bin_io, sexp]
@@ -53,182 +56,337 @@ let update_state_machine : state_machine -> command -> op_result =
 
 let create_state_machine () = Hashtbl.create (module String)
 
-type log_index = int64 [@@deriving bin_io, sexp]
+type log_index = int64 [@@deriving bin_io, sexp, compare]
 
-type term = int [@@deriving compare, equal, bin_io, sexp]
+type term = int [@@deriving compare, compare, bin_io, sexp]
 
-type log_entry = {command: command; term: term} [@@deriving bin_io, sexp]
+type log_entry = {command: command; term: term}
+[@@deriving bin_io, sexp, compare]
 
-module Wal = struct
-  module Term = struct
-    module T = struct
-      type t = term [@@deriving bin_io, sexp]
+(*---- Immutable API -------------------------------*)
 
-      let init () = 0
+module ILog = struct
+  module IdSet = Set.Make (Id)
 
-      type op = t [@@deriving bin_io, sexp]
+  module I = struct
+    type t = {store: log_entry list; command_set: IdSet.t; length: int64}
+    [@@deriving sexp, accessors, compare]
 
-      let apply _t op = op
-    end
+    let nth_of_index t i = Int64.(t.length - i)
 
-    let update_term t op = (T.apply t op, [op])
+    let drop_of_index t i = Int64.(nth_of_index t i + one)
 
-    include T
+    type op = Add of log_entry | RemoveGEQ of log_index
+    [@@deriving bin_io, sexp, compare]
+
+    let init () = {store= []; command_set= IdSet.empty; length= Int64.zero}
+
+    let add t entry =
+      let command_set = Set.add t.command_set entry.command.id in
+      {store= entry :: t.store; command_set; length= Int64.(t.length + of_int 1)}
+
+    let remove_geq t i =
+      let drop = drop_of_index t i |> Int64.(max zero) in
+      let removed, store = List.split_n t.store (Int64.to_int_exn drop) in
+      let command_set =
+        List.fold_left removed ~init:t.command_set ~f:(fun cset entry ->
+            Set.remove cset entry.command.id)
+      in
+      let length = Int64.(max zero (t.length - drop)) in
+      {store; command_set; length}
+
+    let apply t op =
+      match op with Add entry -> add t entry | RemoveGEQ i -> remove_geq t i
   end
 
-  module Log = struct
-    module L = struct
-      module IdSet = Set.Make (Id)
+  type t = I.t [@@deriving sexp, compare]
 
-      type t = {store: log_entry list; command_set: IdSet.t; length: int64}
-      [@@deriving sexp]
+  type op = I.op [@@deriving bin_io, sexp, compare]
 
-      let nth_of_index t i = Int64.(t.length - i)
+  let init = I.init
 
-      let drop_of_index t i = Int64.(nth_of_index t i + one)
+  let apply = I.apply
 
-      let init () = {store= []; command_set= IdSet.empty; length= Int64.zero}
+  let get_index (t : t) index =
+    let nth = I.nth_of_index t index |> Int64.to_int_exn in
+    List.nth t.store nth
+    |> Result.of_option
+         ~error:(Not_found_s (Sexp.Atom (Fmt.str "%a" Fmt.int64 index)))
 
-      type op = Add of log_entry | RemoveGEQ of log_index [@@deriving bin_io, sexp]
+  let get_index_exn t i = get_index t i |> Result.ok_exn
 
-      let add t entry =
-        let command_set = Set.add t.command_set entry.command.id in
-        { store= entry :: t.store
-        ; command_set
-        ; length= Int64.(t.length + of_int 1) }
+  let get_term t index =
+    match index with
+    | i when Int64.(i = zero) ->
+        Ok 0
+    | _ ->
+        let open Result.Monad_infix in
+        get_index t index >>= fun entry -> Ok entry.term
 
-      let remove_geq t i =
-        let drop = drop_of_index t i |> Int64.(max zero) in
-        let removed, store = List.split_n t.store (Int64.to_int_exn drop) in
-        let command_set =
-          List.fold_left removed ~init:t.command_set ~f:(fun cset entry ->
-              Set.remove cset entry.command.id)
-        in
-        let length = Int64.(max zero (t.length - drop)) in
-        {store; command_set; length}
+  let get_term_exn t i = get_term t i |> Result.ok_exn
 
-      let apply t = function
-        | Add entry ->
-            add t entry
-        | RemoveGEQ i ->
-            remove_geq t i
-    end
+  let apply_wrap t op = (I.apply t op, op)
 
-    type t = L.t [@@deriving sexp]
+  let add_entry t e = apply_wrap t (I.Add e)
 
-    type op = L.op [@@deriving bin_io,sexp]
+  let remove_geq t index = apply_wrap t (I.RemoveGEQ index)
 
-    let get (t : L.t) index =
-      let nth = L.nth_of_index t index |> Int64.to_int_exn in
-      List.nth t.store nth
-      |> Result.of_option
-           ~error:(Not_found_s (Sexp.Atom (Fmt.str "%a" Fmt.int64 index)))
+  let get_max_index t = t.I.length
 
-    let get_exn t i = get t i |> Result.ok_exn
+  let mem_id t id = Set.mem t.I.command_set id
 
-    let get_term t index =
-      match index with
-      | i when Int64.(i = zero) ->
-          Ok 0
-      | _ ->
-          let open Result.Monad_infix in
-          get t index >>= fun entry -> Ok entry.term
+  let entries_after_inc t index =
+    let drop = I.drop_of_index t index |> Int64.to_int_exn in
+    List.split_n t.store drop |> fst
 
-    let get_term_exn t index = get_term t index |> Result.ok_exn
+  let entries_after_inc_size t index =
+    let size = Int64.(get_max_index t - index + one) in
+    (entries_after_inc t index, size)
 
-    let apply_wrap t op = (L.apply t op, [op])
+  let to_string t =
+    let entries = entries_after_inc t Int64.zero in
+    [%sexp_of: log_entry list] entries |> Sexp.to_string_hum
 
-    let add entry t = (L.add t entry, L.Add entry)
-
-    let addv cs t term =
-      List.fold cs ~init:(t, []) ~f:(fun (t, ops) command ->
-          let t, op = add {term; command} t in
-          let ops = op :: ops in
-          (t, ops))
-
-    let removeGEQ index t = (L.remove_geq t index, L.RemoveGEQ index)
-
-    let get_max_index (t : L.t) = t.length
-
-    let id_in_log (t : L.t) id = Set.mem t.command_set id
-
-    let entries_after_inc t index =
-      let drop = L.drop_of_index t index |> Int64.to_int_exn in
-      List.split_n t.store drop |> fst
-
-    let entries_after_inc_size t index =
-      let size = Int64.(get_max_index t - index + one) in
-      (entries_after_inc t index, size)
-
-    let to_string t =
-      let entries = entries_after_inc t Int64.zero in
-      [%sexp_of: log_entry list] entries |> Sexp.to_string_hum
-
-    let add_entries_remove_conflicts t ~start_index new_entries =
-      let relevant_entries = entries_after_inc t start_index in
-      (* Takes two lists of entries lowest index first
+  let add_entries_remove_conflicts t ~start_index new_entries =
+    let relevant_entries = entries_after_inc t start_index in
+    (* Takes two lists of entries lowest index first
          iterates through the lists until there is a conflict
          at which point it returns the conflict index and the entries to add
-      *)
-      let rec merge_y_into_x idx :
-          log_entry list * log_entry list -> int64 option * log_entry list =
-        function
-        | _, [] ->
-            (None, [])
-        | [], ys ->
-            (None, ys)
-        | x :: _, (y :: _ as ys) when equal_term x.term y.term ->
-            [%log.debug
-              logger "Mismatch while merging" (x : log_entry) (y : log_entry)] ;
-            Logs.debug (fun m -> m "Mismatch at %a" Fmt.int64 idx) ;
-            (Some idx, ys)
-        | _ :: xs, _ :: ys ->
-            merge_y_into_x Int64.(succ idx) (xs, ys)
-      in
-      (* entries_to_add is in oldest first order *)
-      let removeGEQ_o, entries_to_add =
-        merge_y_into_x start_index
-          (List.rev relevant_entries, List.rev new_entries)
-      in
-      let ops = [] in
-      let t, ops =
-        match removeGEQ_o with
-        | Some i ->
-            let t', op' = apply_wrap t (RemoveGEQ i) in
-            (t', op' @ ops)
-        | None ->
-            (t, ops)
-      in
-      let t, ops =
-        List.fold_left entries_to_add ~init:(t, ops) ~f:(fun (t, ops) v ->
-            let t', ops' = apply_wrap t (Add v) in
-            (t', ops' @ ops))
-      in
-      (t, List.rev ops)
+    *)
+    let rec merge_y_into_x idx :
+        log_entry list * log_entry list -> int64 option * log_entry list =
+      function
+      | _, [] ->
+          (None, [])
+      | [], ys ->
+          (None, ys)
+      | x :: _, (y :: _ as ys) when not @@ [%compare.equal: term] x.term y.term
+        ->
+          [%log.debug
+            logger "Mismatch while merging" (x : log_entry) (y : log_entry)] ;
+          Logs.debug (fun m -> m "Mismatch at %a" Fmt.int64 idx) ;
+          (Some idx, ys)
+      | _ :: xs, _ :: ys ->
+          merge_y_into_x Int64.(succ idx) (xs, ys)
+    in
+    (* entries_to_add is in oldest first order *)
+    let removeGEQ_o, entries_to_add =
+      merge_y_into_x start_index
+        (List.rev relevant_entries, List.rev new_entries)
+    in
+    let t, ops =
+      match removeGEQ_o with
+      | Some i ->
+          let t', op' = apply_wrap t (RemoveGEQ i) in
+          (t', [op'])
+      | None ->
+          (t, [])
+    in
+    let t, ops =
+      List.fold_left entries_to_add ~init:(t, ops) ~f:(fun (t, ops) v ->
+          let t', ops' = apply_wrap t (Add v) in
+          (t', ops' :: ops))
+    in
+    (t, ops)
 
-    let append t command term =
-      let entry = {command; term} in
-      apply_wrap t (Add entry)
-  end
+  let add_cmd t command term = add_entry t {command; term}
 
-  module P = struct
-    type t = {term: Term.t; log: Log.t}
-
-    let init () = {term= Term.init (); log= Log.L.init ()}
-
-    type op = Term of Term.T.op | Log of Log.L.op [@@deriving bin_io, sexp]
-
-    let apply t = function
-      | Term op ->
-          {t with term= Term.T.apply t.term op}
-      | Log op ->
-          {t with log= Log.L.apply t.log op}
-  end
-
-  include Owal.Persistant (P)
+  let add_cmds t cmds term =
+    List.fold cmds ~init:(t, []) ~f:(fun (t, ops) command ->
+        let t, op = add_cmd t command term in
+        let ops = op :: ops in
+        (t, ops))
 end
 
-type log = Wal.Log.L.t
+module ITerm = struct
+  type t = term [@@deriving bin_io, sexp, compare]
+
+  let init () = 0
+
+  type op = t [@@deriving bin_io, sexp, compare]
+
+  let apply _t op = op
+end
+
+module type IStorage = sig
+  type data [@@deriving sexp_of, compare]
+
+  type op [@@deriving sexp, bin_io]
+
+  type t [@@deriving sexp_of, compare]
+
+  val init : unit -> t
+
+  val apply : t -> op -> t
+
+  val get_current_term : t -> term
+
+  val get_data : t -> data
+
+  (* newest to oldest *)
+  val get_ops : t -> op list
+
+  val reset_ops : t -> t
+
+  val update_term : t -> term:term -> t
+
+  val add_entry : t -> entry:log_entry -> t
+
+  val remove_geq : t -> index:log_index -> t
+
+  val get_index : t -> log_index -> (log_entry, exn) result
+
+  val get_index_exn : t -> log_index -> log_entry
+
+  val get_term : t -> log_index -> (term, exn) result
+
+  val get_term_exn : t -> log_index -> term
+
+  val get_max_index : t -> log_index
+
+  val mem_id : t -> command_id -> bool
+
+  val entries_after_inc : t -> log_index -> log_entry list
+
+  val entries_after_inc_size : t -> log_index -> log_entry list * int64
+
+  val to_string : t -> string
+
+  val add_entries_remove_conflicts :
+    t -> start_index:log_index -> entries:log_entry list -> t
+
+  val add_cmd : t -> cmd:command -> term:term -> t
+
+  val add_cmds : t -> cmds:command list -> term:term -> t
+end
+
+module IStorage : IStorage = struct
+  module T = ITerm
+  module L = ILog
+
+  (*---- Immutable API -------------------------------*)
+
+  type op = Term of T.op | Log of L.op
+  [@@deriving bin_io, accessors, sexp, compare]
+
+  type data = {current_term: T.t; log: L.t}
+  [@@deriving sexp_of, accessors, compare]
+
+  (* Newest at head of op list *)
+  type t = {data: data; ops: op list} [@@deriving sexp_of, accessors, compare]
+
+  let init () = {data= {current_term= T.init (); log= L.init ()}; ops= []}
+
+  let apply t op =
+    match op with
+    | Term op ->
+        A.set (data @> current_term) t ~to_:(T.apply t.data.current_term op)
+    | Log op ->
+        A.set (data @> log) t ~to_:(L.apply t.data.log op)
+
+  (* Actual API *)
+
+  let get_current_term t = t.data.current_term
+
+  let get_data t = t.data
+
+  let get_ops t = t.ops
+
+  let reset_ops t = {t with ops= []}
+
+  let update_term t ~term =
+    A.set (data @> current_term) t ~to_:term
+    |> A.set ops ~to_:(Term term :: t.ops)
+
+  let add_entry t ~entry =
+    let l, op = L.add_entry t.data.log entry in
+    A.set (data @> log) t ~to_:l |> A.set ops ~to_:(Log op :: t.ops)
+
+  let remove_geq t ~index =
+    let l, op = L.remove_geq t.data.log index in
+    A.set (data @> log) t ~to_:l |> A.set ops ~to_:(Log op :: t.ops)
+
+  let get_index t index = L.get_index t.data.log index
+
+  let get_index_exn t index = L.get_index_exn t.data.log index
+
+  let get_term t index = L.get_term t.data.log index
+
+  let get_term_exn t index = L.get_term_exn t.data.log index
+
+  let get_max_index t = L.get_max_index t.data.log
+
+  let mem_id t id = L.mem_id t.data.log id
+
+  let entries_after_inc t index = L.entries_after_inc t.data.log index
+
+  let entries_after_inc_size t index = L.entries_after_inc_size t.data.log index
+
+  let to_string t = [%message (t : t)] |> Sexp.to_string_hum
+
+  let add_entries_remove_conflicts t ~start_index ~entries =
+    let l, ops' =
+      L.add_entries_remove_conflicts t.data.log ~start_index entries
+    in
+    A.set (data @> log) t ~to_:l
+    |> A.set ops ~to_:(List.map ~f:(fun op -> Log op) ops' @ t.ops)
+
+  let add_cmd t ~cmd ~term =
+    let l, op = L.add_cmd t.data.log cmd term in
+    A.set (data @> log) t ~to_:l |> A.set ops ~to_:(Log op :: t.ops)
+
+  let add_cmds t ~cmds ~term =
+    let l, ops' = L.add_cmds t.data.log cmds term in
+    A.set (data @> log) t ~to_:l
+    |> A.set ops ~to_:(List.map ~f:(fun op -> Log op) ops' @ t.ops)
+end
+
+module MutableStorage (I : IStorage) : sig
+  type wal
+
+  type t = {mutable state: I.t; wal: wal} [@@deriving sexp_of, accessors]
+
+  val get_state : t -> I.t
+
+  val update : t -> I.t -> [`SyncPossible | `NoSync]
+
+  val of_path : ?file_size:int64 -> string -> t Deferred.t
+
+  val datasync : t -> log_index Deferred.t
+
+  val close : t -> unit Deferred.t
+end = struct
+  module P = Owal.Persistant (I)
+
+  type wal = P.t
+
+  type t = {mutable state: I.t; wal: wal} [@@deriving accessors]
+
+  let get_state t = t.state
+
+  let sexp_of_t t = [%message (t.state : I.t)]
+
+  let update t i' =
+    t.state <- I.reset_ops i' ;
+    match I.get_ops i' with
+    | [] ->
+        `NoSync
+    | ops ->
+        (* get oldest to newest ordering of ops *)
+        List.iter ~f:(P.write t.wal) (List.rev ops) ;
+        `SyncPossible
+
+  let of_path ?file_size path =
+    let%map wal, state = P.of_path ?file_size path in
+    {state; wal}
+
+  let datasync t =
+    let max_index = I.get_max_index t.state in
+    let%bind () = P.datasync t.wal in
+    return max_index
+
+  let close t = P.close t.wal
+end
 
 module MessageTypes = struct
   type request_vote = {src: node_id; term: term; leader_commit: log_index}

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -69,6 +69,7 @@ module ILog = struct
   module IdSet = Set.Make (Id)
 
   module I = struct
+    (* store is in newest to oldest order*)
     type t = {store: log_entry list; command_set: IdSet.t; length: int64}
     [@@deriving sexp, accessors, compare]
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -185,12 +185,11 @@ module Wal = struct
         | _ :: xs, _ :: ys ->
             merge_y_into_x Int64.(succ idx) (xs, ys)
       in
+      (* entries_to_add is in oldest first order *)
       let removeGEQ_o, entries_to_add =
         merge_y_into_x start_index
           (List.rev relevant_entries, List.rev new_entries)
       in
-      (* entries_to_add is in oldest first order *)
-      let entries_to_add = entries_to_add in
       let ops = [] in
       let t, ops =
         match removeGEQ_o with

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -260,7 +260,8 @@ module MessageTypes = struct
 
   type client_request = command [@@deriving bin_io, sexp]
 
-  type client_response = op_result [@@deriving bin_io, sexp]
+  type client_response = (op_result, [`Unapplied]) Result.t
+  [@@deriving bin_io, sexp]
 end
 
 module RPCs = struct

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -80,3 +80,5 @@ let connect_persist ?(retry_delay = Time_ns.Span.of_sec 1.) name =
       | Error exn ->
           Error (Error.of_exn exn) |> return)
     (fun () -> Ok server_address |> return)
+
+type 'a rd_wr_pipe = {rd: 'a Pipe.Reader.t; wr: 'a Pipe.Writer.t}

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -61,7 +61,7 @@ module Batcher = struct
       f xs
     in
     create ~f ~dispatch_timeout ~limit:(fun _ ->
-        incr counter ; !counter > limit)
+        incr counter ; !counter > limit )
 end
 
 let connect_persist ?(retry_delay = Time_ns.Span.of_sec 1.) name =
@@ -78,7 +78,7 @@ let connect_persist ?(retry_delay = Time_ns.Span.of_sec 1.) name =
       | Ok v ->
           Ok v |> return
       | Error exn ->
-          Error (Error.of_exn exn) |> return)
+          Error (Error.of_exn exn) |> return )
     (fun () -> Ok server_address |> return)
 
 type 'a rd_wr_pipe = {rd: 'a Pipe.Reader.t; wr: 'a Pipe.Writer.t}

--- a/ocamlpaxos.opam
+++ b/ocamlpaxos.opam
@@ -8,10 +8,12 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "core"
   "async"
+  "accessor_async"
   "rpc_parallel"
   "ppx_jane"
   "ppx_log"
   "ppx_deriving_yojson"
+  "ppx_accessor"
   "dune"
   "logs"
   "fmt"

--- a/ocamlpaxos.opam
+++ b/ocamlpaxos.opam
@@ -12,6 +12,7 @@ depends: [
   "ppx_jane"
   "ppx_log"
   "ppx_deriving_yojson"
+  "ppx_accessor"
   "dune"
   "logs"
   "fmt"

--- a/ocamlpaxos.opam
+++ b/ocamlpaxos.opam
@@ -18,6 +18,7 @@ depends: [
   "fmt"
   "owl"
   "core_bench"
+  "core_profiler"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/ocamlpaxos.opam
+++ b/ocamlpaxos.opam
@@ -8,6 +8,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "core"
   "async"
+  "rpc_parallel"
   "ppx_jane"
   "ppx_log"
   "ppx_deriving_yojson"

--- a/ocamlpaxos.opam
+++ b/ocamlpaxos.opam
@@ -12,13 +12,11 @@ depends: [
   "ppx_jane"
   "ppx_log"
   "ppx_deriving_yojson"
-  "ppx_accessor"
   "dune"
   "logs"
   "fmt"
   "owl"
   "core_bench"
-  "core_profiler"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/scripts/dune
+++ b/scripts/dune
@@ -1,0 +1,5 @@
+(executables 
+  (names micro_bench)
+  (libraries ppx_jane core shexp.process angstrom fmt)
+  (preprocess (pps ppx_jane -allow-unannotated-ignores))
+  )

--- a/scripts/dune
+++ b/scripts/dune
@@ -1,5 +1,5 @@
-(executables 
-  (names micro_bench)
-  (libraries ppx_jane core shexp.process angstrom fmt)
-  (preprocess (pps ppx_jane -allow-unannotated-ignores))
-  )
+(executables
+ (names micro_bench)
+ (libraries ppx_jane core shexp.process angstrom fmt)
+ (preprocess
+  (pps ppx_jane -allow-unannotated-ignores)))

--- a/scripts/micro_bench.ml
+++ b/scripts/micro_bench.ml
@@ -14,6 +14,10 @@ let set_core_profiler output = set_env "CORE_PROFILER" ("OUTPUT_FILE=" ^ output)
 
 let if_exists f file = if%bind file_exists file then f file else return ()
 
+let delay t p =
+  let%bind () = sleep t in
+  p
+
 let start_server node_id =
   let data_dir = Fmt.str "%d.datadir" node_id in
   let%bind () = if_exists rm_rf data_dir in
@@ -57,9 +61,7 @@ let print_summary file =
   call ["core-profiler-tool"; "summary"; "-filename"; file]
 
 let test target_rate =
-  let%bind () = print @@ Fmt.str "Built main\n" in
-  let%bind () = sleep 1. in
-  let%bind bgs = fork_all [start_server 1; start_server 2] in
+  let%bind bgs = fork_all [start_server 1; delay 1. @@ start_server 2] in
   let%bind exit_code = client_test [1; 2] target_rate in
   let%bind () = List'.iter bgs ~f:kill in
   match exit_code with
@@ -77,7 +79,12 @@ let () =
         flag "rate" (optional_with_default 5000 int) ~doc:"N Target rate"
       and trace = flag "trace" no_arg ~doc:" Print a trace of the test" in
       fun () ->
-        let () = eval (call ["dune"; "build"; "bin/main.exe"] ) in
+        let () =
+          eval
+            (call ["dune"; "build"; "bin/main.exe"; "scripts/micro_bench.exe"])
+        in
+        let () = eval (sleep 5.) in
+        let () = eval (print @@ Fmt.str "Built main\n") in
         match trace with
         | true ->
             let (), trace = Traced.eval_exn @@ test rate in

--- a/scripts/micro_bench.ml
+++ b/scripts/micro_bench.ml
@@ -23,33 +23,34 @@ let start_server node_id =
   let%bind () = if_exists rm prof_file in
   let port = node_id + 4 |> Int.to_string in
   let node_id = Int.to_string node_id in
-  let bg = 
-  spawn "dune"
-  @@ ["exec"; "bin/main.exe"; "--"]
-  @ [node_id; "1:127.0.0.1:5002,2:127.0.0.1:6002,3:127.0.0.1:7002"; data_dir]
-  @ [port ^ "001"; port ^ "002"]
-  @ ["5"; "5"] @ ["-s"; "100"]
-  @ ["-log-to-file"; log_dir ^ "/logger"]
-  |> set_core_profiler prof_file
-  |> redirect
-       Std_io.[Stdout]
-       ~perm:0o777
-       ~flags:Unix.[O_RDWR; O_CREAT]
-       (log_dir ^ "/stdout")
-  |> redirect
-       Std_io.[Stderr]
-       ~perm:0o777
-       ~flags:Unix.[O_RDWR; O_CREAT]
-       (log_dir ^ "/stderr")
-  in return @@ eval bg 
+  let bg =
+    spawn "dune"
+    @@ ["exec"; "bin/main.exe"; "--"]
+    @ [node_id; "1:127.0.0.1:5002,2:127.0.0.1:6002,3:127.0.0.1:7002"; data_dir]
+    @ [port ^ "001"; port ^ "002"]
+    @ ["5"; "0.1"] @ ["-s"; "100"] @ ["-log-level"; "debug"]
+    @ ["-log-to-file"; log_dir ^ "/logger"]
+    |> set_core_profiler prof_file
+    |> redirect
+         Std_io.[Stdout]
+         ~perm:0o777
+         ~flags:Unix.[O_RDWR; O_CREAT]
+         (log_dir ^ "/stdout")
+    |> redirect
+         Std_io.[Stderr]
+         ~perm:0o777
+         ~flags:Unix.[O_RDWR; O_CREAT]
+         (log_dir ^ "/stderr")
+  in
+  return @@ eval bg
 
 let client_test nodes rate =
-  let nodes = List.map nodes ~f:(fun i -> ((i + 5) * 1000) + 1) in
+  let nodes = List.map nodes ~f:(fun i -> ((i + 4) * 1000) + 1) in
   let nodes = nodes |> [%sexp_of: int list] |> Sexp.to_string in
-  call_exit_code
-  @@ ["timeout"; "1m"]
+  call_exit_code @@ ["timeout"; "1m"]
   @ ["dune"; "exec"; "bin/bench.exe"; "--"]
   @ ["-p"; nodes] @ ["-t"; Int.to_string rate] @ ["-n"; "100000"]
+  @ ["-log-level"; "debug"]
 
 let print_summary file =
   call ["core-profiler-tool"; "summary"; "-filename"; file]
@@ -65,7 +66,7 @@ let test target_rate =
     | 0 ->
         List'.iter [1; 2] ~f:(fun node -> print_summary (Fmt.str "%d.dat" node))
     | 124 ->
-      print @@ Fmt.str "Benchmark timed out\n"
+        print @@ Fmt.str "Benchmark timed out\n"
     | v ->
         print @@ Fmt.str "Test was not successful with code %d\n" v
   in

--- a/scripts/micro_bench.ml
+++ b/scripts/micro_bench.ml
@@ -28,7 +28,7 @@ let start_server node_id =
   @@ ["exec"; "bin/main.exe"; "--"]
   @ [node_id; "1:127.0.0.1:5002,2:127.0.0.1:6002,3:127.0.0.1:7002"; data_dir]
   @ [port ^ "001"; port ^ "002"]
-  @ ["5"; "0.1"] @ ["-s"; "100"] @ ["-log-level"; "info"]
+  @ ["5"; "0.1"] @ ["-s"; "500"] @ ["-log-level"; "info"]
   @ ["-log-to-file"; log_dir ^ "/logger"]
   |> set_core_profiler prof_file
   |> redirect

--- a/scripts/micro_bench.ml
+++ b/scripts/micro_bench.ml
@@ -1,0 +1,83 @@
+open! Shexp_process
+open! Shexp_process.Infix
+open! Shexp_process.Let_syntax
+module List' = List
+open! Core
+
+let kill bg =
+  let pid = Background_command.pid bg in
+  let%bind () = call ["kill"; Int.to_string pid] in
+  wait bg |> map ~f:(fun _ -> ())
+
+let set_core_profiler output = set_env "CORE_PROFILER" ("OUTPUT_FILE=" ^ output)
+
+let rm_f file = if%bind file_exists file then rm_rf file else return ()
+
+let start_server node_id =
+  let data_dir = Fmt.str "%d.datadir" node_id in
+  let%bind () = rm_f data_dir in
+  let log_dir = Fmt.str "%d.log" node_id in
+  let%bind () = rm_f log_dir in
+  let%bind () = mkdir ~perm:0o0777 log_dir in
+  let port = node_id + 4 |> Int.to_string in
+  let node_id = Int.to_string node_id in
+  spawn "dune"
+  @@ ["exec"; "bin/main.exe"; "--"]
+  @ [node_id; "1:127.0.0.1:5002,2:127.0.0.1:6002,3:127.0.0.1:7002"; data_dir]
+  @ [port ^ "001"; port ^ "002"]
+  @ ["5"; "5"] @ ["-s"; "100"]
+  |> set_core_profiler (node_id ^ ".dat")
+  |> redirect
+       Std_io.[Stdout]
+       ~perm:0o777
+       ~flags:Unix.[O_RDWR; O_CREAT]
+       (log_dir ^ "/stdout")
+  |> redirect
+       Std_io.[Stderr]
+       ~perm:0o777
+       ~flags:Unix.[O_RDWR; O_CREAT]
+       (log_dir ^ "/stderr")
+
+let client_test nodes rate =
+  let nodes = List.map nodes ~f:(fun i -> ((i + 5) * 1000) + 1) in
+  let nodes = nodes |> [%sexp_of: int list] |> Sexp.to_string in
+  call
+    [ "dune"
+    ; "exec"
+    ; "bin/bench.exe"
+    ; "--"
+    ; "-p"
+    ; nodes
+    ; "-t"
+    ; Int.to_string rate
+    ; "-n"
+    ; "100000" ]
+
+let print_summary file =
+  call ["core-profiler-tool"; "summary"; "-filename"; file]
+
+let test target_rate =
+  let%bind () = call ["dune"; "build"; "@install"] in
+  let%bind () = print @@ Fmt.str "Built main\n" in
+  let%bind () = sleep 1. in
+  let%bind bgs = fork_all [start_server 1; start_server 2] in
+  let%bind () = client_test [1; 2] target_rate in
+  let%bind () =
+    List'.iter [1; 2] ~f:(fun node -> print_summary (Fmt.str "%d.dat" node))
+  in
+  List'.iter bgs ~f:(fun bg -> kill bg)
+
+let () =
+  Command.basic ~summary:"Script for automating benchmarking"
+    [%map_open.Command
+      let rate =
+        flag "rate" (optional_with_default 5000 int) ~doc:"N Target rate"
+      and trace = flag "trace" no_arg ~doc:" Print a trace of the test" in
+      fun () ->
+        match trace with
+        | true ->
+            let (), trace = Traced.eval_exn @@ test rate in
+            trace |> Sexp.to_string_hum |> print_endline
+        | false ->
+            eval (test rate)]
+  |> Command.run

--- a/scripts/micro_bench.ml
+++ b/scripts/micro_bench.ml
@@ -11,22 +11,26 @@ let kill bg =
 
 let set_core_profiler output = set_env "CORE_PROFILER" ("OUTPUT_FILE=" ^ output)
 
-let rm_f file = if%bind file_exists file then rm_rf file else return ()
+let if_exists f file = if%bind file_exists file then f file else return ()
 
 let start_server node_id =
   let data_dir = Fmt.str "%d.datadir" node_id in
-  let%bind () = rm_f data_dir in
+  let%bind () = if_exists rm_rf data_dir in
   let log_dir = Fmt.str "%d.log" node_id in
-  let%bind () = rm_f log_dir in
+  let%bind () = if_exists rm_rf log_dir in
   let%bind () = mkdir ~perm:0o0777 log_dir in
+  let prof_file = Fmt.str "%d.dat" node_id in
+  let%bind () = if_exists rm prof_file in
   let port = node_id + 4 |> Int.to_string in
   let node_id = Int.to_string node_id in
+  let bg = 
   spawn "dune"
   @@ ["exec"; "bin/main.exe"; "--"]
   @ [node_id; "1:127.0.0.1:5002,2:127.0.0.1:6002,3:127.0.0.1:7002"; data_dir]
   @ [port ^ "001"; port ^ "002"]
   @ ["5"; "5"] @ ["-s"; "100"]
-  |> set_core_profiler (node_id ^ ".dat")
+  @ ["-log-to-file"; log_dir ^ "/logger"]
+  |> set_core_profiler prof_file
   |> redirect
        Std_io.[Stdout]
        ~perm:0o777
@@ -37,21 +41,15 @@ let start_server node_id =
        ~perm:0o777
        ~flags:Unix.[O_RDWR; O_CREAT]
        (log_dir ^ "/stderr")
+  in return @@ eval bg 
 
 let client_test nodes rate =
   let nodes = List.map nodes ~f:(fun i -> ((i + 5) * 1000) + 1) in
   let nodes = nodes |> [%sexp_of: int list] |> Sexp.to_string in
-  call
-    [ "dune"
-    ; "exec"
-    ; "bin/bench.exe"
-    ; "--"
-    ; "-p"
-    ; nodes
-    ; "-t"
-    ; Int.to_string rate
-    ; "-n"
-    ; "100000" ]
+  call_exit_code
+  @@ ["timeout"; "1m"]
+  @ ["dune"; "exec"; "bin/bench.exe"; "--"]
+  @ ["-p"; nodes] @ ["-t"; Int.to_string rate] @ ["-n"; "100000"]
 
 let print_summary file =
   call ["core-profiler-tool"; "summary"; "-filename"; file]
@@ -61,9 +59,15 @@ let test target_rate =
   let%bind () = print @@ Fmt.str "Built main\n" in
   let%bind () = sleep 1. in
   let%bind bgs = fork_all [start_server 1; start_server 2] in
-  let%bind () = client_test [1; 2] target_rate in
+  let%bind exit_code = client_test [1; 2] target_rate in
   let%bind () =
-    List'.iter [1; 2] ~f:(fun node -> print_summary (Fmt.str "%d.dat" node))
+    match exit_code with
+    | 0 ->
+        List'.iter [1; 2] ~f:(fun node -> print_summary (Fmt.str "%d.dat" node))
+    | 124 ->
+      print @@ Fmt.str "Benchmark timed out\n"
+    | v ->
+        print @@ Fmt.str "Test was not successful with code %d\n" v
   in
   List'.iter bgs ~f:(fun bg -> kill bg)
 

--- a/scripts/micro_bench.ml
+++ b/scripts/micro_bench.ml
@@ -6,6 +6,7 @@ open! Core
 
 let kill bg =
   let pid = Background_command.pid bg in
+  let%bind () = print @@ Fmt.str "Killing %d\n" pid in
   let%bind () = call ["kill"; Int.to_string pid] in
   wait bg |> map ~f:(fun _ -> ())
 
@@ -23,54 +24,51 @@ let start_server node_id =
   let%bind () = if_exists rm prof_file in
   let port = node_id + 4 |> Int.to_string in
   let node_id = Int.to_string node_id in
-  let bg =
-    spawn "dune"
-    @@ ["exec"; "bin/main.exe"; "--"]
-    @ [node_id; "1:127.0.0.1:5002,2:127.0.0.1:6002,3:127.0.0.1:7002"; data_dir]
-    @ [port ^ "001"; port ^ "002"]
-    @ ["5"; "0.1"] @ ["-s"; "100"] @ ["-log-level"; "debug"]
-    @ ["-log-to-file"; log_dir ^ "/logger"]
-    |> set_core_profiler prof_file
-    |> redirect
-         Std_io.[Stdout]
-         ~perm:0o777
-         ~flags:Unix.[O_RDWR; O_CREAT]
-         (log_dir ^ "/stdout")
-    |> redirect
-         Std_io.[Stderr]
-         ~perm:0o777
-         ~flags:Unix.[O_RDWR; O_CREAT]
-         (log_dir ^ "/stderr")
-  in
-  return @@ eval bg
+  spawn "dune"
+  @@ ["exec"; "bin/main.exe"; "--"]
+  @ [node_id; "1:127.0.0.1:5002,2:127.0.0.1:6002,3:127.0.0.1:7002"; data_dir]
+  @ [port ^ "001"; port ^ "002"]
+  @ ["5"; "0.1"] @ ["-s"; "100"] @ ["-log-level"; "info"]
+  @ ["-log-to-file"; log_dir ^ "/logger"]
+  |> set_core_profiler prof_file
+  |> redirect
+       Std_io.[Stdout]
+       ~perm:0o777
+       ~flags:Unix.[O_RDWR; O_CREAT]
+       (log_dir ^ "/stdout")
+  |> redirect
+       Std_io.[Stderr]
+       ~perm:0o777
+       ~flags:Unix.[O_RDWR; O_CREAT]
+       (log_dir ^ "/stderr")
 
 let client_test nodes rate =
+  let test_length = 10 in
+  let n = rate * test_length in
+  let timeout = Fmt.str "%ds" (test_length * 5) in
   let nodes = List.map nodes ~f:(fun i -> ((i + 4) * 1000) + 1) in
   let nodes = nodes |> [%sexp_of: int list] |> Sexp.to_string in
-  call_exit_code @@ ["timeout"; "1m"]
+  call_exit_code @@ ["timeout"; timeout]
   @ ["dune"; "exec"; "bin/bench.exe"; "--"]
-  @ ["-p"; nodes] @ ["-t"; Int.to_string rate] @ ["-n"; "100000"]
-  @ ["-log-level"; "debug"]
+  @ ["-p"; nodes] @ ["-t"; Int.to_string rate] @ ["-n"; Int.to_string n]
+  @ ["-log-level"; "info"]
 
 let print_summary file =
   call ["core-profiler-tool"; "summary"; "-filename"; file]
 
 let test target_rate =
-  let%bind () = call ["dune"; "build"; "@install"] in
   let%bind () = print @@ Fmt.str "Built main\n" in
   let%bind () = sleep 1. in
   let%bind bgs = fork_all [start_server 1; start_server 2] in
   let%bind exit_code = client_test [1; 2] target_rate in
-  let%bind () =
-    match exit_code with
-    | 0 ->
-        List'.iter [1; 2] ~f:(fun node -> print_summary (Fmt.str "%d.dat" node))
-    | 124 ->
-        print @@ Fmt.str "Benchmark timed out\n"
-    | v ->
-        print @@ Fmt.str "Test was not successful with code %d\n" v
-  in
-  List'.iter bgs ~f:(fun bg -> kill bg)
+  let%bind () = List'.iter bgs ~f:kill in
+  match exit_code with
+  | 0 ->
+      List'.iter [1; 2] ~f:(fun node -> print_summary (Fmt.str "%d.dat" node))
+  | 124 ->
+      print @@ Fmt.str "Benchmark timed out\n"
+  | v ->
+      print @@ Fmt.str "Test was not successful with code %d\n" v
 
 let () =
   Command.basic ~summary:"Script for automating benchmarking"
@@ -79,6 +77,7 @@ let () =
         flag "rate" (optional_with_default 5000 int) ~doc:"N Target rate"
       and trace = flag "trace" no_arg ~doc:" Print a trace of the test" in
       fun () ->
+        let () = eval (call ["dune"; "build"; "bin/main.exe"] ) in
         match trace with
         | true ->
             let (), trace = Traced.eval_exn @@ test rate in

--- a/test/log.ml
+++ b/test/log.ml
@@ -1,119 +1,450 @@
 open! Core
-open! Async
 open! Ocamlpaxos
 open Types
-module L = Types.Wal.Log
-
-let with_file f path =
-  let%bind wal, Wal.P.{log; _} = Wal.of_path path in
-  let%bind () = f (wal, log) in
-  Wal.close wal
+module L = Types.ILog
+module T = Types.ITerm
+module IS = Types.IStorage
+module PS = Types.MutableStorage (IS)
 
 let make_entry id term key =
   let id = Types.Id.of_int_exn id in
   let command = Types.Command.{op= Read (Int.to_string key); id} in
   Types.{command; term}
 
-let init_log (wal, log) =
-  let init_state =
-    [(1, 1); (1, 2); (3, 3); (3, 4)]
-    |> List.mapi ~f:(fun id (term, key) -> make_entry (id + 1) term key)
-  in
-  let fold log entry =
-    let log, op = L.add entry log in
-    Wal.write wal (Log op) ; log
-  in
-  let log = List.fold_left init_state ~init:log ~f:fold in
-  let%bind () = Wal.datasync wal in
-  return log
+module IStorageTest = struct
+  let init_log istate =
+    let ops =
+      [(1, 1); (1, 2); (3, 3); (3, 4)]
+      |> List.mapi ~f:(fun id (term, key) -> make_entry (id + 1) term key)
+    in
+    List.fold_left ops ~init:istate ~f:(fun istate entry ->
+        IS.add_entry istate ~entry)
 
-let%expect_test "id_in_log" =
-  let path = "id_in_log.wal" in
-  let f (wal, log) =
-    L.id_in_log log (Types.Id.of_int_exn 1) |> Bool.to_string |> print_endline ;
-    let%bind () = [%expect {| false |}] in
-    let%bind log = init_log (wal, log) in
-    L.id_in_log log (Types.Id.of_int_exn 1) |> Bool.to_string |> print_endline ;
-    let%bind () = [%expect {| true |}] in
-    return ()
-  in
-  with_file f path
+  let%expect_test "init_log" =
+    let istate = IS.init () in
+    istate |> IS.to_string |> print_endline ;
+    [%expect
+      {|
+      (t
+       ((data ((current_term 0) (log ((store ()) (command_set ()) (length 0)))))
+        (ops ()))) |}] ;
+    let istate = init_log istate in
+    istate |> IS.to_string |> print_endline ;
+    [%expect
+      {|
+      (t
+       ((data
+         ((current_term 0)
+          (log
+           ((store
+             (((command ((op (Read 4)) (id 4))) (term 3))
+              ((command ((op (Read 3)) (id 3))) (term 3))
+              ((command ((op (Read 2)) (id 2))) (term 1))
+              ((command ((op (Read 1)) (id 1))) (term 1))))
+            (command_set (1 2 3 4)) (length 4)))))
+        (ops
+         ((Log (Add ((command ((op (Read 4)) (id 4))) (term 3))))
+          (Log (Add ((command ((op (Read 3)) (id 3))) (term 3))))
+          (Log (Add ((command ((op (Read 2)) (id 2))) (term 1))))
+          (Log (Add ((command ((op (Read 1)) (id 1))) (term 1)))))))) |}] ;
+    istate |> [%sexp_of: IS.t] |> Sexp.to_string_hum |> print_endline ;
+    [%expect
+      {|
+      ((data
+        ((current_term 0)
+         (log
+          ((store
+            (((command ((op (Read 4)) (id 4))) (term 3))
+             ((command ((op (Read 3)) (id 3))) (term 3))
+             ((command ((op (Read 2)) (id 2))) (term 1))
+             ((command ((op (Read 1)) (id 1))) (term 1))))
+           (command_set (1 2 3 4)) (length 4)))))
+       (ops
+        ((Log (Add ((command ((op (Read 4)) (id 4))) (term 3))))
+         (Log (Add ((command ((op (Read 3)) (id 3))) (term 3))))
+         (Log (Add ((command ((op (Read 2)) (id 2))) (term 1))))
+         (Log (Add ((command ((op (Read 1)) (id 1))) (term 1))))))) |}]
 
-let%expect_test "get_term" =
-  let path = "term_test.wal" in
-  let f (wal, log) =
-    L.get_term_exn log (Int64.of_int 0)
+  let%expect_test "get_ops" =
+    let istate = IS.init () |> init_log in
+    IS.get_ops istate |> [%sexp_of: IS.op list] |> Sexp.to_string_hum
+    |> print_endline ;
+    [%expect
+      {|
+      ((Log (Add ((command ((op (Read 4)) (id 4))) (term 3))))
+       (Log (Add ((command ((op (Read 3)) (id 3))) (term 3))))
+       (Log (Add ((command ((op (Read 2)) (id 2))) (term 1))))
+       (Log (Add ((command ((op (Read 1)) (id 1))) (term 1))))) |}]
+
+  let%expect_test "reset_ops" =
+    let istate = IS.init () |> init_log in
+    let istate = IS.reset_ops istate in
+    istate |> [%sexp_of: IS.t] |> Sexp.to_string_hum |> print_endline ;
+    [%expect
+      {|
+      ((data
+        ((current_term 0)
+         (log
+          ((store
+            (((command ((op (Read 4)) (id 4))) (term 3))
+             ((command ((op (Read 3)) (id 3))) (term 3))
+             ((command ((op (Read 2)) (id 2))) (term 1))
+             ((command ((op (Read 1)) (id 1))) (term 1))))
+           (command_set (1 2 3 4)) (length 4)))))
+       (ops ())) |}]
+
+  let%expect_test "update_term" =
+    let istate = IS.init () |> init_log in
+    istate |> [%sexp_of: IS.t] |> Sexp.to_string_hum |> print_endline ;
+    let istate = IS.update_term istate ~term:5 in
+    istate |> [%sexp_of: IS.t] |> Sexp.to_string_hum |> print_endline ;
+    [%expect
+      {|
+      ((data
+        ((current_term 0)
+         (log
+          ((store
+            (((command ((op (Read 4)) (id 4))) (term 3))
+             ((command ((op (Read 3)) (id 3))) (term 3))
+             ((command ((op (Read 2)) (id 2))) (term 1))
+             ((command ((op (Read 1)) (id 1))) (term 1))))
+           (command_set (1 2 3 4)) (length 4)))))
+       (ops
+        ((Log (Add ((command ((op (Read 4)) (id 4))) (term 3))))
+         (Log (Add ((command ((op (Read 3)) (id 3))) (term 3))))
+         (Log (Add ((command ((op (Read 2)) (id 2))) (term 1))))
+         (Log (Add ((command ((op (Read 1)) (id 1))) (term 1)))))))
+      ((data
+        ((current_term 5)
+         (log
+          ((store
+            (((command ((op (Read 4)) (id 4))) (term 3))
+             ((command ((op (Read 3)) (id 3))) (term 3))
+             ((command ((op (Read 2)) (id 2))) (term 1))
+             ((command ((op (Read 1)) (id 1))) (term 1))))
+           (command_set (1 2 3 4)) (length 4)))))
+       (ops
+        ((Term 5) (Log (Add ((command ((op (Read 4)) (id 4))) (term 3))))
+         (Log (Add ((command ((op (Read 3)) (id 3))) (term 3))))
+         (Log (Add ((command ((op (Read 2)) (id 2))) (term 1))))
+         (Log (Add ((command ((op (Read 1)) (id 1))) (term 1))))))) |}]
+
+  let%expect_test "add_entry" =
+    let istate = IS.init () in
+    istate |> [%sexp_of: IS.t] |> Sexp.to_string_hum |> print_endline ;
+    let istate = IS.add_entry istate ~entry:(make_entry 5 4 3) in
+    istate |> [%sexp_of: IS.t] |> Sexp.to_string_hum |> print_endline ;
+    [%expect
+      {|
+      ((data ((current_term 0) (log ((store ()) (command_set ()) (length 0)))))
+       (ops ()))
+      ((data
+        ((current_term 0)
+         (log
+          ((store (((command ((op (Read 3)) (id 5))) (term 4)))) (command_set (5))
+           (length 1)))))
+       (ops ((Log (Add ((command ((op (Read 3)) (id 5))) (term 4))))))) |}]
+
+  let%expect_test "remove_geq" =
+    let istate = IS.init () |> init_log in
+    let istate = IS.remove_geq istate ~index:Int64.(of_int 3) in
+    istate |> [%sexp_of: IS.t] |> Sexp.to_string_hum |> print_endline ;
+    [%expect
+      {|
+      ((data
+        ((current_term 0)
+         (log
+          ((store
+            (((command ((op (Read 2)) (id 2))) (term 1))
+             ((command ((op (Read 1)) (id 1))) (term 1))))
+           (command_set (1 2)) (length 2)))))
+       (ops
+        ((Log (RemoveGEQ 3))
+         (Log (Add ((command ((op (Read 4)) (id 4))) (term 3))))
+         (Log (Add ((command ((op (Read 3)) (id 3))) (term 3))))
+         (Log (Add ((command ((op (Read 2)) (id 2))) (term 1))))
+         (Log (Add ((command ((op (Read 1)) (id 1))) (term 1))))))) |}]
+
+  let%expect_test "get_index" =
+    let istate = IS.init () |> init_log in
+    IS.get_index istate (Int64.of_int 0)
+    |> [%sexp_of: (Types.log_entry, exn) Result.t] |> Sexp.to_string_hum
+    |> print_endline ;
+    [%expect {| (Error (Not_found_s 0)) |}] ;
+    IS.get_index_exn istate (Int64.of_int 1)
+    |> [%sexp_of: Types.log_entry] |> Sexp.to_string_hum |> print_endline ;
+    [%expect {| ((command ((op (Read 1)) (id 1))) (term 1)) |}] ;
+    IS.get_index_exn istate (Int64.of_int 2)
+    |> [%sexp_of: Types.log_entry] |> Sexp.to_string_hum |> print_endline ;
+    [%expect {| ((command ((op (Read 2)) (id 2))) (term 1)) |}]
+
+  let%expect_test "get_term" =
+    let istate = IS.init () |> init_log in
+    IS.get_term_exn istate (Int64.of_int 0)
     |> [%sexp_of: Types.term] |> Sexp.to_string_hum |> print_endline ;
-    let%bind () = [%expect {| 0 |}] in
-    let%bind log = init_log (wal, log) in
-    L.get_term_exn log (Int64.of_int 0)
+    [%expect {| 0 |}] ;
+    IS.get_term_exn istate (Int64.of_int 1)
     |> [%sexp_of: Types.term] |> Sexp.to_string_hum |> print_endline ;
-    let%bind () = [%expect {| 0 |}] in
-    L.get_term_exn log (Int64.of_int 1)
+    [%expect {| 1 |}] ;
+    IS.get_term_exn istate (Int64.of_int 2)
     |> [%sexp_of: Types.term] |> Sexp.to_string_hum |> print_endline ;
-    let%bind () = [%expect {| 1 |}] in
-    L.get_term_exn log (Int64.of_int 2)
+    [%expect {| 1 |}] ;
+    IS.get_term_exn istate (Int64.of_int 3)
     |> [%sexp_of: Types.term] |> Sexp.to_string_hum |> print_endline ;
-    let%bind () = [%expect {| 1 |}] in
-    L.get_term_exn log (Int64.of_int 3)
+    [%expect {| 3 |}] ;
+    IS.get_term_exn istate (Int64.of_int 4)
     |> [%sexp_of: Types.term] |> Sexp.to_string_hum |> print_endline ;
     [%expect {| 3 |}]
-  in
-  with_file f path
 
-let%expect_test "to_string" =
-  let path = "to_string.wal" in
-  let f (wal, log) =
-    let%bind log = init_log (wal, log) in
-    log |> L.to_string |> print_endline ;
+  let%expect_test "get_max_index" =
+    let istate = IS.init () in
+    istate |> IS.get_max_index |> Int64.to_string |> print_endline ;
+    [%expect {| 0 |}] ;
+    let istate = init_log istate in
+    istate |> IS.get_max_index |> Int64.to_string |> print_endline ;
+    [%expect {| 4 |}]
+
+  let%expect_test "mem_id" =
+    let istate = IS.init () in
+    IS.mem_id istate (Types.Id.of_int_exn 1) |> Bool.to_string |> print_endline ;
+    [%expect {| false |}] ;
+    let istate = init_log istate in
+    IS.mem_id istate (Types.Id.of_int_exn 1) |> Bool.to_string |> print_endline ;
+    [%expect {| true |}]
+
+  let%expect_test "entries_after_inc" =
+    let istate = IS.init () |> init_log in
+    let entries = IS.entries_after_inc istate Int64.(of_int 2) in
+    entries |> [%sexp_of: log_entry list] |> Sexp.to_string_hum |> print_endline ;
     [%expect
       {|
       (((command ((op (Read 4)) (id 4))) (term 3))
        ((command ((op (Read 3)) (id 3))) (term 3))
-       ((command ((op (Read 2)) (id 2))) (term 1))
-       ((command ((op (Read 1)) (id 1))) (term 1))) |}]
-  in
-  with_file f path
+       ((command ((op (Read 2)) (id 2))) (term 1))) |}]
 
-let%expect_test "max_index" =
-  let path = "max_index.wal" in
-  let f (wal, log) =
-    log |> L.get_max_index |> Int64.to_string |> print_endline ;
-    let%bind () = [%expect {| 0 |}] in
-    let%bind log = init_log (wal, log) in
-    log |> L.get_max_index |> Int64.to_string |> print_endline ;
-    [%expect {| 4 |}]
-  in
-  with_file f path
+  let%expect_test "entries_after_inc_size" =
+    let istate = IS.init () |> init_log in
+    let entries = IS.entries_after_inc_size istate Int64.(of_int 2) in
+    entries |> [%sexp_of: log_entry list * int64] |> Sexp.to_string_hum
+    |> print_endline ;
+    [%expect
+      {|
+      ((((command ((op (Read 4)) (id 4))) (term 3))
+        ((command ((op (Read 3)) (id 3))) (term 3))
+        ((command ((op (Read 2)) (id 2))) (term 1)))
+       3) |}]
 
-let%expect_test "add_entries_rem_conflicts" =
-  let path = "add_entries" in
-  let f (wal, log) =
-    let%bind log = init_log (wal, log) in
+  let%expect_test "add_entries_rem_conflicts" =
+    let istate = IS.init () |> init_log in
+    istate |> IS.to_string |> print_endline ;
+    [%expect
+      {|
+      (t
+       ((data
+         ((current_term 0)
+          (log
+           ((store
+             (((command ((op (Read 4)) (id 4))) (term 3))
+              ((command ((op (Read 3)) (id 3))) (term 3))
+              ((command ((op (Read 2)) (id 2))) (term 1))
+              ((command ((op (Read 1)) (id 1))) (term 1))))
+            (command_set (1 2 3 4)) (length 4)))))
+        (ops
+         ((Log (Add ((command ((op (Read 4)) (id 4))) (term 3))))
+          (Log (Add ((command ((op (Read 3)) (id 3))) (term 3))))
+          (Log (Add ((command ((op (Read 2)) (id 2))) (term 1))))
+          (Log (Add ((command ((op (Read 1)) (id 1))) (term 1)))))))) |}] ;
     let entries =
-      List.map [(3, 3, 3); (2, 1, 2)] ~f:(fun (a, b, c) -> make_entry a b c)
+      List.map [(3, 4, 3); (2, 1, 2)] ~f:(fun (a, b, c) -> make_entry a b c)
     in
-    let log, _ =
-      L.add_entries_remove_conflicts log ~start_index:(Int64.of_int 2) entries
+    let istate =
+      IS.add_entries_remove_conflicts istate ~start_index:(Int64.of_int 2)
+        ~entries
     in
-    log |> L.to_string |> print_endline ;
+    istate |> IS.to_string |> print_endline ;
     [%expect
       {|
-      (((command ((op (Read 3)) (id 3))) (term 3))
-       ((command ((op (Read 2)) (id 2))) (term 1))
-       ((command ((op (Read 1)) (id 1))) (term 1))) |}]
-  in
-  with_file f path
+      (t
+       ((data
+         ((current_term 0)
+          (log
+           ((store
+             (((command ((op (Read 3)) (id 3))) (term 4))
+              ((command ((op (Read 2)) (id 2))) (term 1))
+              ((command ((op (Read 1)) (id 1))) (term 1))))
+            (command_set (1 2 3)) (length 3)))))
+        (ops
+         ((Log (Add ((command ((op (Read 3)) (id 3))) (term 4))))
+          (Log (RemoveGEQ 3))
+          (Log (Add ((command ((op (Read 4)) (id 4))) (term 3))))
+          (Log (Add ((command ((op (Read 3)) (id 3))) (term 3))))
+          (Log (Add ((command ((op (Read 2)) (id 2))) (term 1))))
+          (Log (Add ((command ((op (Read 1)) (id 1))) (term 1)))))))) |}]
 
-let%expect_test "rem_geq" =
-  let path = "rem_get.wal" in
-  let f (wal, log) =
-    let%bind log = init_log (wal, log) in
-    let log, _ = L.removeGEQ Int64.(of_int 3) log in
-    log |> L.to_string |> print_endline ;
+  let%expect_test "add_cmd" =
+    let istate = IS.init () |> init_log in
+    let istate =
+      IS.add_cmd istate
+        ~cmd:Types.Command.{op= Read "cmd1"; id= Id.of_int_exn 11}
+        ~term:10
+    in
+    istate |> [%sexp_of: IS.t] |> Sexp.to_string_hum |> print_endline ;
     [%expect
       {|
-       (((command ((op (Read 2)) (id 2))) (term 1))
-        ((command ((op (Read 1)) (id 1))) (term 1))) |}]
-  in
-  with_file f path
+      ((data
+        ((current_term 0)
+         (log
+          ((store
+            (((command ((op (Read cmd1)) (id 11))) (term 10))
+             ((command ((op (Read 4)) (id 4))) (term 3))
+             ((command ((op (Read 3)) (id 3))) (term 3))
+             ((command ((op (Read 2)) (id 2))) (term 1))
+             ((command ((op (Read 1)) (id 1))) (term 1))))
+           (command_set (1 2 3 4 11)) (length 5)))))
+       (ops
+        ((Log (Add ((command ((op (Read cmd1)) (id 11))) (term 10))))
+         (Log (Add ((command ((op (Read 4)) (id 4))) (term 3))))
+         (Log (Add ((command ((op (Read 3)) (id 3))) (term 3))))
+         (Log (Add ((command ((op (Read 2)) (id 2))) (term 1))))
+         (Log (Add ((command ((op (Read 1)) (id 1))) (term 1))))))) |}]
+
+  let%expect_test "add_cmds" =
+    let istate = IS.init () |> init_log in
+    let istate =
+      IS.add_cmds istate
+        ~cmds:
+          Types.Command.
+            [ {op= Read "cmd1"; id= Id.of_int_exn 11}
+            ; {op= Read "cmd2"; id= Id.of_int_exn 12} ]
+        ~term:10
+    in
+    istate |> [%sexp_of: IS.t] |> Sexp.to_string_hum |> print_endline ;
+    [%expect
+      {|
+      ((data
+        ((current_term 0)
+         (log
+          ((store
+            (((command ((op (Read cmd2)) (id 12))) (term 10))
+             ((command ((op (Read cmd1)) (id 11))) (term 10))
+             ((command ((op (Read 4)) (id 4))) (term 3))
+             ((command ((op (Read 3)) (id 3))) (term 3))
+             ((command ((op (Read 2)) (id 2))) (term 1))
+             ((command ((op (Read 1)) (id 1))) (term 1))))
+           (command_set (1 2 3 4 11 12)) (length 6)))))
+       (ops
+        ((Log (Add ((command ((op (Read cmd2)) (id 12))) (term 10))))
+         (Log (Add ((command ((op (Read cmd1)) (id 11))) (term 10))))
+         (Log (Add ((command ((op (Read 4)) (id 4))) (term 3))))
+         (Log (Add ((command ((op (Read 3)) (id 3))) (term 3))))
+         (Log (Add ((command ((op (Read 2)) (id 2))) (term 1))))
+         (Log (Add ((command ((op (Read 1)) (id 1))) (term 1))))))) |}]
+end
+
+module MStoreTest = struct
+  open! Async
+
+  let with_file f path =
+    let%bind s = PS.of_path path in
+    let%bind () = f s in
+    PS.close s
+
+  let init_log istate =
+    let ops =
+      [(1, 1); (1, 2); (3, 3); (3, 4)]
+      |> List.mapi ~f:(fun id (term, key) -> make_entry (id + 1) term key)
+    in
+    List.fold_left ops ~init:istate ~f:(fun istate entry ->
+        IS.add_entry istate ~entry)
+
+  let%expect_test "end-to-end" =
+    let f store =
+      let istate = PS.get_state store in
+      let entries =
+        List.map [(3, 4, 3); (2, 1, 2)] ~f:(fun (a, b, c) -> make_entry a b c)
+      in
+      let istate = istate |> init_log in
+      PS.update store istate |> ignore ;
+      let istate = IS.reset_ops istate in
+      let%bind idx = PS.datasync store in
+      idx |> [%sexp_of: int64] |> Sexp.to_string_hum |> print_endline ;
+      let%bind () = [%expect {| 4 |}] in
+      let istate' =
+        IS.add_entries_remove_conflicts istate ~start_index:(Int64.of_int 2)
+          ~entries
+        |> IS.update_term ~term:100
+      in
+      let ops = List.rev @@ IS.get_ops istate' in
+      let istate'' = List.fold_left ops ~f:IS.apply ~init:istate in
+      [%message (istate : IS.t) (istate' : IS.t) (istate'' : IS.t)]
+      |> Sexp.to_string_hum |> print_endline ;
+      let%bind () =
+        [%expect
+          {|
+        ((istate
+          ((data
+            ((current_term 0)
+             (log
+              ((store
+                (((command ((op (Read 4)) (id 4))) (term 3))
+                 ((command ((op (Read 3)) (id 3))) (term 3))
+                 ((command ((op (Read 2)) (id 2))) (term 1))
+                 ((command ((op (Read 1)) (id 1))) (term 1))))
+               (command_set (1 2 3 4)) (length 4)))))
+           (ops ())))
+         (istate'
+          ((data
+            ((current_term 100)
+             (log
+              ((store
+                (((command ((op (Read 3)) (id 3))) (term 4))
+                 ((command ((op (Read 2)) (id 2))) (term 1))
+                 ((command ((op (Read 1)) (id 1))) (term 1))))
+               (command_set (1 2 3)) (length 3)))))
+           (ops
+            ((Term 100) (Log (Add ((command ((op (Read 3)) (id 3))) (term 4))))
+             (Log (RemoveGEQ 3))))))
+         (istate''
+          ((data
+            ((current_term 100)
+             (log
+              ((store
+                (((command ((op (Read 3)) (id 3))) (term 4))
+                 ((command ((op (Read 2)) (id 2))) (term 1))
+                 ((command ((op (Read 1)) (id 1))) (term 1))))
+               (command_set (1 2 3)) (length 3)))))
+           (ops ())))) |}]
+      in
+      [%message
+        ( [%compare.equal: IS.data] (IS.get_data istate') (IS.get_data istate'')
+          : bool )]
+      |> Sexp.to_string_hum |> print_endline ;
+      let%bind () =
+        [%expect
+          {|
+        ("([%compare.equal :IS.data]) (IS.get_data istate') (IS.get_data istate'')"
+         true) |}]
+      in
+      PS.update store istate' |> ignore ;
+      let%bind idx = PS.datasync store in
+      idx |> [%sexp_of: int64] |> Sexp.to_string_hum |> print_endline ;
+      [%expect {| 3 |}]
+    in
+    let%bind () = with_file f "end-to-end" in
+    let f' store =
+      PS.get_state store |> [%sexp_of: IS.t] |> Sexp.to_string_hum
+      |> print_endline ;
+      [%expect
+        {|
+        ((data
+          ((current_term 100)
+           (log
+            ((store
+              (((command ((op (Read 3)) (id 3))) (term 4))
+               ((command ((op (Read 2)) (id 2))) (term 1))
+               ((command ((op (Read 1)) (id 1))) (term 1))))
+             (command_set (1 2 3)) (length 3)))))
+         (ops ())) |}]
+    in
+    with_file f' "end-to-end"
+end

--- a/test/log.ml
+++ b/test/log.ml
@@ -18,7 +18,7 @@ module IStorageTest = struct
       |> List.mapi ~f:(fun id (term, key) -> make_entry (id + 1) term key)
     in
     List.fold_left ops ~init:istate ~f:(fun istate entry ->
-        IS.add_entry istate ~entry)
+        IS.add_entry istate ~entry )
 
   let%expect_test "init_log" =
     let istate = IS.init () in
@@ -355,7 +355,7 @@ module MStoreTest = struct
       |> List.mapi ~f:(fun id (term, key) -> make_entry (id + 1) term key)
     in
     List.fold_left ops ~init:istate ~f:(fun istate entry ->
-        IS.add_entry istate ~entry)
+        IS.add_entry istate ~entry )
 
   let%expect_test "end-to-end" =
     let f store =
@@ -422,7 +422,7 @@ module MStoreTest = struct
       let%bind () =
         [%expect
           {|
-        ("([%compare.equal :IS.data]) (IS.get_data istate') (IS.get_data istate'')"
+        ("([%compare.equal : IS.data]) (IS.get_data istate') (IS.get_data istate'')"
          true) |}]
       in
       PS.update store istate' |> ignore ;

--- a/test/pcore.ml
+++ b/test/pcore.ml
@@ -3,7 +3,8 @@ open! Async
 open! Ocamlpaxos
 module P = Paxos_core
 
-let cmd_of_int i = Types.Command.{op= Read (Int.to_string i); id= Types.Id.of_int_exn i}
+let cmd_of_int i =
+  Types.Command.{op= Read (Int.to_string i); id= Types.Id.of_int_exn i}
 
 let single_config =
   P.

--- a/test/pcore.ml
+++ b/test/pcore.ml
@@ -209,7 +209,7 @@ let%expect_test "loop triple" =
       | `SendRequestVote (dst, rv) when dst = 1 ->
           Some rv
       | _ ->
-          None)
+          None )
   in
   let t1, actions = P.advance t1 (`RRequestVote rv) |> get_ok in
   let t1 = print_state t1 actions in
@@ -229,7 +229,7 @@ let%expect_test "loop triple" =
       | `SendRequestVoteResponse (id, rvr) when id = 2 ->
           Some rvr
       | _ ->
-          None)
+          None )
   in
   let t2, actions = P.advance t2 (`RRequestVoteResponse rvr) |> get_ok in
   let t2 = print_state t2 actions in
@@ -294,7 +294,7 @@ let%expect_test "loop triple" =
       | `SendAppendEntries (id, ae) when id = 1 ->
           Some ae
       | _ ->
-          None)
+          None )
   in
   let t2, actions = P.advance t2 (`Syncd (Int64.of_int 2)) |> get_ok in
   let t2 = print_state t2 actions in
@@ -339,7 +339,7 @@ let%expect_test "loop triple" =
       | `SendAppendEntriesResponse (id, aer) when id = 2 ->
           Some aer
       | _ ->
-          None)
+          None )
   in
   (* In case of full update *)
   let () =

--- a/test/pcore.ml
+++ b/test/pcore.ml
@@ -2,6 +2,7 @@ open! Core
 open! Ocamlpaxos
 module P = Paxos_core
 module S = Types.IStorage
+open! P.Test.StateR.Let_syntax
 
 let cmd_of_int i =
   Types.Command.{op= Read (Int.to_string i); id= Types.Id.of_int_exn i}
@@ -24,17 +25,24 @@ let three_config =
     ; node_id= 1
     ; election_timeout= 1 }
 
-let pr_err = function
+let pr_err s p =
+  match P.Test.StateR.eval p s with
   | Error (`Msg s) ->
       print_endline @@ Fmt.str "Error: %s" s
   | Ok _ ->
       ()
 
-let get_ok = function
+let get_result s p =
+  match P.Test.StateR.eval p s with
   | Error (`Msg s) ->
       raise @@ Invalid_argument s
-  | Ok v ->
-      v
+  | Ok ((), {t; a= actions}) ->
+      (t, actions)
+
+let get_ok = function
+  | Error (`Msg s) ->
+    raise @@ Invalid_argument s
+  | Ok v -> v
 
 let print_state (t : P.t) actions =
   let t, store = P.pop_store t in
@@ -43,13 +51,15 @@ let print_state (t : P.t) actions =
   |> Sexp.to_string_hum |> print_endline ;
   t
 
+let make_empty t = P.Test.State.empty t
+
 let%expect_test "transitions" =
   let store = S.init () in
   let t = P.create_node three_config store in
-  let () = P.Test.transition_to_leader t |> pr_err in
+  let () = pr_err (make_empty t) @@ P.Test.transition_to_leader () in
   [%expect
     {| Error: Cannot transition to leader from states other than candidate |}] ;
-  let t, actions = P.Test.transition_to_candidate t |> get_ok in
+  let t, actions = P.Test.transition_to_candidate () |> get_result (make_empty t) in
   print_endline @@ Fmt.str "%d" (P.get_term t) ;
   [%expect {| 1 |}] ;
   let t = print_state t actions in
@@ -57,7 +67,7 @@ let%expect_test "transitions" =
     {|
     (("P.Test.get_node_state t"
       (Candidate (quorum ((elts (1)) (n 1) (threshold 2) (eq <fun>)))
-       (entries ()) (start_index 1)))
+       (entries ()) (start_index 1) (timeout 0)))
      (store
       ((data ((current_term 1) (log ((store ()) (command_set ()) (length 0)))))
        (ops ((Term 1)))))
@@ -66,7 +76,7 @@ let%expect_test "transitions" =
         ((SendRequestVote (2 ((src 1) (term 1) (leader_commit 0))))
          (SendRequestVote (3 ((src 1) (term 1) (leader_commit 0))))))
        (nonblock_sync false)))) |}] ;
-  let t, actions = P.Test.transition_to_leader t |> get_ok in
+  let t, actions = P.Test.transition_to_leader () |> get_result (make_empty t) in
   let t = print_state t actions in
   let _ = t in
   [%expect
@@ -80,11 +90,11 @@ let%expect_test "transitions" =
      (actions
       ((acts
         ((SendAppendEntries
-          (2
+          (3
            ((src 1) (term 1) (prev_log_index 0) (prev_log_term 0) (entries ())
             (entries_length 0) (leader_commit 0))))
          (SendAppendEntries
-          (3
+          (2
            ((src 1) (term 1) (prev_log_index 0) (prev_log_term 0) (entries ())
             (entries_length 0) (leader_commit 0))))))
        (nonblock_sync false)))) |}]
@@ -98,7 +108,7 @@ let%expect_test "tick" =
     {|
     (("P.Test.get_node_state t"
       (Candidate (quorum ((elts (1)) (n 1) (threshold 2) (eq <fun>)))
-       (entries ()) (start_index 1)))
+       (entries ()) (start_index 1) (timeout 0)))
      (store
       ((data ((current_term 1) (log ((store ()) (command_set ()) (length 0)))))
        (ops ((Term 1)))))
@@ -107,12 +117,12 @@ let%expect_test "tick" =
         ((SendRequestVote (2 ((src 1) (term 1) (leader_commit 0))))
          (SendRequestVote (3 ((src 1) (term 1) (leader_commit 0))))))
        (nonblock_sync false)))) |}] ;
-  let t, _ = P.Test.transition_to_follower t |> get_ok in
+  let t, _ = P.Test.transition_to_follower () |> get_result (make_empty t) in
   let t, actions = P.advance t `Tick |> get_ok in
   let _t = print_state t actions in
   [%expect
     {|
-    (("P.Test.get_node_state t" (Follower (heartbeat 1)))
+    (("P.Test.get_node_state t" (Follower (timeout 1)))
      (store
       ((data ((current_term 1) (log ((store ()) (command_set ()) (length 0)))))
        (ops ())))
@@ -127,7 +137,7 @@ let%expect_test "loop single" =
   let t = print_state t actions in
   [%expect
     {|
-    (("P.Test.get_node_state t" (Follower (heartbeat 1)))
+    (("P.Test.get_node_state t" (Follower (timeout 1)))
      (store
       ((data ((current_term 0) (log ((store ()) (command_set ()) (length 0)))))
        (ops ())))
@@ -195,7 +205,7 @@ let%expect_test "loop triple" =
     {|
     (("P.Test.get_node_state t"
       (Candidate (quorum ((elts (2)) (n 1) (threshold 2) (eq <fun>)))
-       (entries ()) (start_index 1)))
+       (entries ()) (start_index 1) (timeout 0)))
      (store
       ((data ((current_term 2) (log ((store ()) (command_set ()) (length 0)))))
        (ops ((Term 2)))))
@@ -215,7 +225,7 @@ let%expect_test "loop triple" =
   let t1 = print_state t1 actions in
   [%expect
     {|
-    (("P.Test.get_node_state t" (Follower (heartbeat 0)))
+    (("P.Test.get_node_state t" (Follower (timeout 0)))
      (store
       ((data ((current_term 2) (log ((store ()) (command_set ()) (length 0)))))
        (ops ((Term 2)))))
@@ -244,11 +254,11 @@ let%expect_test "loop triple" =
      (actions
       ((acts
         ((SendAppendEntries
-          (1
+          (3
            ((src 2) (term 2) (prev_log_index 0) (prev_log_term 0) (entries ())
             (entries_length 0) (leader_commit 0))))
          (SendAppendEntries
-          (3
+          (1
            ((src 2) (term 2) (prev_log_index 0) (prev_log_term 0) (entries ())
             (entries_length 0) (leader_commit 0))))))
        (nonblock_sync true)))) |}] ;
@@ -275,14 +285,14 @@ let%expect_test "loop triple" =
      (actions
       ((acts
         ((SendAppendEntries
-          (1
+          (3
            ((src 2) (term 2) (prev_log_index 0) (prev_log_term 0)
             (entries
              (((command ((op (Read 2)) (id 2))) (term 2))
               ((command ((op (Read 1)) (id 1))) (term 2))))
             (entries_length 2) (leader_commit 0))))
          (SendAppendEntries
-          (3
+          (1
            ((src 2) (term 2) (prev_log_index 0) (prev_log_term 0)
             (entries
              (((command ((op (Read 2)) (id 2))) (term 2))
@@ -318,7 +328,7 @@ let%expect_test "loop triple" =
   let _ = t1 in
   [%expect
     {|
-    (("P.Test.get_node_state t" (Follower (heartbeat 0)))
+    (("P.Test.get_node_state t" (Follower (timeout 0)))
      (store
       ((data
         ((current_term 2)
@@ -343,7 +353,9 @@ let%expect_test "loop triple" =
   in
   (* In case of full update *)
   let () =
-    let t2, actions = P.advance t2 (`RAppendEntiresResponse aer) |> get_ok in
+    let t2, actions =
+      P.advance t2 (`RAppendEntiresResponse aer) |> get_ok
+    in
     let _t2 = print_state t2 actions in
     [%expect
       {|
@@ -370,7 +382,9 @@ let%expect_test "loop triple" =
       | _ ->
           assert false
     in
-    let t2, actions = P.advance t2 (`RAppendEntiresResponse aer) |> get_ok in
+    let t2, actions =
+      P.advance t2 (`RAppendEntiresResponse aer) |> get_ok
+    in
     let t2 = print_state t2 actions in
     let _ = t2 in
     [%expect
@@ -389,18 +403,20 @@ let%expect_test "loop triple" =
          (ops ())))
        (actions
         ((acts
-          ((SendAppendEntries
+          ((CommitIndexUpdate 1)
+           (SendAppendEntries
             (1
              ((src 2) (term 2) (prev_log_index 1) (prev_log_term 2)
               (entries (((command ((op (Read 2)) (id 2))) (term 2))))
-              (entries_length 1) (leader_commit 0))))
-           (CommitIndexUpdate 1)))
+              (entries_length 1) (leader_commit 0))))))
          (nonblock_sync true)))) |}]
   in
   (* In case of a failed update *)
   let () =
     let aer = {aer with success= Error Int64.one} in
-    let t2, actions = P.advance t2 (`RAppendEntiresResponse aer) |> get_ok in
+    let t2, actions =
+      P.advance t2 (`RAppendEntiresResponse aer) |> get_ok
+    in
     let t2 = print_state t2 actions in
     let _ = t2 in
     [%expect

--- a/test/wal.ml
+++ b/test/wal.ml
@@ -36,7 +36,7 @@ let%expect_test "persist data" =
   let t =
     List.fold_left [1; 2; 3; 4] ~init:t ~f:(fun t i ->
         let op = T_p.Write i in
-        write wal op ; T_p.apply t op)
+        write wal op ; T_p.apply t op )
   in
   let%bind () = datasync wal in
   [%sexp_of: int list] t |> Sexp.to_string_hum |> print_endline ;

--- a/test/wal.ml
+++ b/test/wal.ml
@@ -44,6 +44,7 @@ let%expect_test "persist data" =
   let%bind () = close wal in
   let%bind wal, t = of_path ~file_size path in
   [%sexp_of: int list] t |> Sexp.to_string_hum |> print_endline ;
-  let%bind () = [%expect {| (4 3 2 1) |}] in
+  let%bind () = [%expect {|
+    (4 3 2 1) |}] in
   let%bind () = close wal in
   return ()

--- a/test/wal.ml
+++ b/test/wal.ml
@@ -8,7 +8,7 @@ module T_p = struct
 
   let init () = []
 
-  type op = Write of int [@@deriving bin_io]
+  type op = Write of int [@@deriving bin_io, sexp]
 
   let apply t (Write i) = i :: t
 end


### PR DESCRIPTION
Use parallel processing to protect the internal operations from external requests.

The main issue for previous version was that the internal requests would be delayed by external requests, resulting in very high latencies.

Thus this PR aims to protect those by separating them into another process space.

In order to not just move which requests are overloading the system, the main process will  now explicitly request a batch from the client side, which should result in only a single outstanding request for the client event queue.

TODO
- [x] Update the client
- [x] Use windowing on uncommitted log entries to avoid overloading other nodes.
